### PR TITLE
Feat/#20 21 22 entities pagination dto

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ public class SwaggerConfig {
 
 모든 API는 `ApiResponse<T>` 형식으로 응답합니다.
 
+### 기본 응답 형식
+
 ```json
 {
   "timestamp": "2025-06-30T01:43:07.956473",
@@ -287,6 +289,38 @@ public class SwaggerConfig {
   "message": "요청이 성공적으로 처리되었습니다.",
   "data": {
     // 실제 데이터 👍
+  }
+}
+```
+
+### 페이지네이션 응답 형식
+
+목록 조회 API에서 페이지네이션이 필요한 경우 `PagedResponse<T>`를 사용합니다.
+
+```java
+@GetMapping("/members")
+public ApiResponse<PagedResponse<MemberDto>> getMembers(
+    @RequestParam(defaultValue = "1") int page,
+    @RequestParam(defaultValue = "10") int limit) {
+    
+    List<MemberDto> members = memberService.getMembers(page, limit);
+    int totalPage = memberService.getTotalPage(limit);
+    
+    PagedResponse<MemberDto> pagedData = PagedResponse.of(members, limit, page, totalPage);
+    return ApiResponse.success(pagedData);
+}
+```
+
+응답 예시:
+```json
+{
+  "data": {
+    "content": [...],
+    "pagination": {
+      "limit": 10,
+      "currentPage": 1,
+      "totalPage": 5
+    }
   }
 }
 ```

--- a/src/main/java/com/divary/common/dto/BasePaginationDto.java
+++ b/src/main/java/com/divary/common/dto/BasePaginationDto.java
@@ -1,0 +1,32 @@
+package com.divary.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "페이지네이션 정보")
+public class BasePaginationDto {
+    
+    @Schema(description = "페이지당 조회 개수", example = "10")
+    private int limit;
+    
+    @Schema(description = "현재 페이지 번호", example = "1")
+    private int currentPage;
+    
+    @Schema(description = "전체 페이지 수", example = "5")
+    private int totalPage;
+    
+    public static BasePaginationDto of(int limit, int currentPage, int totalPage) {
+        return BasePaginationDto.builder()
+                .limit(limit)
+                .currentPage(currentPage)
+                .totalPage(totalPage)
+                .build();
+    }
+}

--- a/src/main/java/com/divary/common/response/PagedResponse.java
+++ b/src/main/java/com/divary/common/response/PagedResponse.java
@@ -1,0 +1,38 @@
+package com.divary.common.response;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "페이지네이션 응답 데이터")
+public class PagedResponse<T> {
+    
+    @ArraySchema(schema = @Schema(description = "조회된 데이터 목록"))
+    private List<T> content;
+    
+    @Schema(description = "페이지네이션 정보")
+    private BasePaginationDto pagination;
+    
+    public static <T> PagedResponse<T> of(List<T> content, BasePaginationDto pagination) {
+        return PagedResponse.<T>builder()
+                .content(content)
+                .pagination(pagination)
+                .build();
+    }
+    
+    public static <T> PagedResponse<T> of(List<T> content, int limit, int currentPage, int totalPage) {
+        return PagedResponse.<T>builder()
+                .content(content)
+                .pagination(BasePaginationDto.of(limit, currentPage, totalPage))
+                .build();
+    }
+}

--- a/src/main/java/com/divary/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/com/divary/domain/chatroom/entity/ChatRoom.java
@@ -1,0 +1,64 @@
+package com.divary.domain.chatroom.entity;
+
+import com.divary.common.entity.BaseEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Map;
+
+@Entity
+@Table(name = "chat_rooms")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "채팅방 엔티티")
+public class ChatRoom extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    @Schema(description = "사용자 ID", example = "1")
+    private Long userId;
+
+    @Column(name = "public_id", nullable = false, length = 21)
+    @Schema(description = "공개 채팅방 ID", example = "chat_12345abcde67890fg")
+    private String publicId;
+
+    @Column(name = "title", nullable = false, length = 20)
+    @Schema(description = "채팅방 제목", example = "해양생물 문의")
+    private String title;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "messages", columnDefinition = "JSON")
+    @Schema(description = "채팅 메시지들 (JSON 형태)")
+    private Map<String, Object> messages;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "metadata", columnDefinition = "JSON")
+    @Schema(description = "채팅방 메타데이터 (JSON 형태)")
+    private Map<String, Object> metadata;
+
+    @Builder
+    public ChatRoom(Long userId, String publicId, String title, Map<String, Object> messages, Map<String, Object> metadata) {
+        this.userId = userId;
+        this.publicId = publicId;
+        this.title = title;
+        this.messages = messages;
+        this.metadata = metadata;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateMessages(Map<String, Object> messages) {
+        this.messages = messages;
+    }
+
+    public void updateMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+}

--- a/src/main/java/com/divary/domain/chatroom/entity/ChatRoom.java
+++ b/src/main/java/com/divary/domain/chatroom/entity/ChatRoom.java
@@ -23,10 +23,6 @@ public class ChatRoom extends BaseEntity {
     @Schema(description = "사용자 ID", example = "1")
     private Long userId;
 
-    @Column(name = "public_id", nullable = false, length = 21)
-    @Schema(description = "공개 채팅방 ID", example = "chat_12345abcde67890fg")
-    private String publicId;
-
     @Column(name = "title", nullable = false, length = 20)
     @Schema(description = "채팅방 제목", example = "해양생물 문의")
     private String title;
@@ -42,9 +38,8 @@ public class ChatRoom extends BaseEntity {
     private Map<String, Object> metadata;
 
     @Builder
-    public ChatRoom(Long userId, String publicId, String title, Map<String, Object> messages, Map<String, Object> metadata) {
+    public ChatRoom(Long userId, String title, Map<String, Object> messages, Map<String, Object> metadata) {
         this.userId = userId;
-        this.publicId = publicId;
         this.title = title;
         this.messages = messages;
         this.metadata = metadata;

--- a/src/main/java/com/divary/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/divary/domain/chatroom/repository/ChatRoomRepository.java
@@ -1,0 +1,19 @@
+package com.divary.domain.chatroom.repository;
+
+import com.divary.domain.chatroom.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    // 공개 ID로 채팅방 조회
+    Optional<ChatRoom> findByPublicId(String publicId);
+
+    // 사용자 ID로 채팅방 목록 조회
+    List<ChatRoom> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 공개 ID 존재 여부 확인
+    boolean existsByPublicId(String publicId);
+}

--- a/src/main/java/com/divary/domain/image/entity/Image.java
+++ b/src/main/java/com/divary/domain/image/entity/Image.java
@@ -1,0 +1,58 @@
+package com.divary.domain.image.entity;
+
+import com.divary.common.entity.BaseEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "image")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "이미지 엔티티")
+public class Image extends BaseEntity {
+
+    @Column(name = "s3_key", nullable = false, length = 255)
+    @Schema(description = "S3 저장 키", example = "users/user_abc123/profile/uuid-filename.jpg")
+    private String s3Key;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    @Schema(description = "이미지 타입", example = "PROFILE")
+    private ImageType type;
+
+    @Column(name = "original_filename", nullable = false, length = 255)
+    @Schema(description = "원본 파일명", example = "diving_photo.jpg")
+    private String originalFilename;
+
+    @Column(name = "width")
+    @Schema(description = "이미지 너비", example = "1920")
+    private Long width;
+
+    @Column(name = "height")
+    @Schema(description = "이미지 높이", example = "1080")
+    private Long height;
+
+    @Column(name = "user_id")
+    @Schema(description = "업로드한 사용자 ID", example = "1")
+    private Long userId;
+
+    @Builder
+    public Image(String s3Key, ImageType type, String originalFilename, Long width, Long height, Long userId) {
+        this.s3Key = s3Key;
+        this.type = type;
+        this.originalFilename = originalFilename;
+        this.width = width;
+        this.height = height;
+        this.userId = userId;
+    }
+
+    // 이미지 정보 업데이트
+    public void updateDimensions(Long width, Long height) {
+        this.width = width;
+        this.height = height;
+    }
+}

--- a/src/main/java/com/divary/domain/image/entity/Image.java
+++ b/src/main/java/com/divary/domain/image/entity/Image.java
@@ -21,7 +21,7 @@ public class Image extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type")
-    @Schema(description = "이미지 타입", example = "PROFILE")
+    @Schema(description = "이미지 타입", example = "DOGAM")
     private ImageType type;
 
     @Column(name = "original_filename", nullable = false, length = 255)

--- a/src/main/java/com/divary/domain/image/entity/ImageType.java
+++ b/src/main/java/com/divary/domain/image/entity/ImageType.java
@@ -1,0 +1,9 @@
+package com.divary.domain.image.entity;
+
+public enum ImageType {
+    DIVING_LOG, // 다이빙 로그 이미지
+    CHAT, // 채팅 이미지
+    LISENCE, // 라이센스 이미지
+    DOGAM, // 도감 이미지
+    DOGAM_PROFILE, // 도감 프로필 이미지
+}


### PR DESCRIPTION

## 🔗 관련 이슈
#22 #21 #20 

---

## 📌 PR 요약

- ChatRoom, Image 도메인 엔티티 추가
- 공통 페이지네이션 DTO 및 응답 클래스 구현
- README 문서 업데이트

---
## 💡 추가 참고 사항
pagination을 적용하실 때 일관된 형태로 응답하기 위해 반드시 해당 래퍼 클래스를 사용해주세요.
@Schema까지는 엔티티에 작성할 필요없는데 이해를 돕기 위해 추가해뒀습니다.
