### PR TITLE
[FEATURE] 게시글 업데이트 시 이미지 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ target/
 .gradle/
 build/
 
+### Eclipse ###
+bin/
+.metadata
+
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/java/com/divary/DivaryApplication.java
+++ b/src/main/java/com/divary/DivaryApplication.java
@@ -4,8 +4,10 @@ import com.divary.global.config.properties.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DivaryApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/divary/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/divary/domain/chatroom/service/ChatRoomService.java
@@ -90,7 +90,7 @@ public class ChatRoomService {
             String firstMessageId = (String) metadata.get("lastMessageId");
             HashMap<String, Object> userMessage = TypeConverter.castToHashMap(messages.get(firstMessageId));
 
-            processImageUpload(userMessage, request.getImage(), userId, savedChatRoom.getId().toString());
+            processImageUpload(userMessage, request.getImage(), userId, savedChatRoom.getId());
 
             messages.put(firstMessageId, userMessage);
             savedChatRoom.updateMessages(messages);
@@ -121,7 +121,7 @@ public class ChatRoomService {
         HashMap<String, Object> messageData = messageFactory.createUserMessageData(request.getMessage(), null);
 
         // 이미지 처리
-        processImageUpload(messageData, request.getImage(), userId, chatRoom.getId().toString());
+        processImageUpload(messageData, request.getImage(), userId, chatRoom.getId());
 
         messages.put(newMessageId, messageData);
 
@@ -168,7 +168,7 @@ public class ChatRoomService {
     
     
     // 이미지 업로드 처리
-    private void processImageUpload(HashMap<String, Object> messageData, MultipartFile image, Long userId, String chatRoomId) {
+    private void processImageUpload(HashMap<String, Object> messageData, MultipartFile image, Long userId, Long chatRoomId) {
         if (image != null && !image.isEmpty()) {
             ImageResponse imageResponse = imageService.uploadImageByType(
                 ImageType.USER_CHAT,

--- a/src/main/java/com/divary/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/divary/domain/chatroom/service/ChatRoomService.java
@@ -10,7 +10,7 @@ import com.divary.domain.chatroom.dto.response.OpenAIResponse;
 import com.divary.domain.chatroom.entity.ChatRoom;
 import com.divary.domain.chatroom.repository.ChatRoomRepository;
 import com.divary.domain.image.dto.response.ImageResponse;
-import com.divary.domain.image.entity.ImageType;
+import com.divary.domain.image.enums.ImageType;
 import com.divary.domain.image.service.ImageService;
 import com.divary.global.exception.BusinessException;
 import com.divary.global.exception.ErrorCode;

--- a/src/main/java/com/divary/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/divary/domain/chatroom/service/ChatRoomService.java
@@ -17,6 +17,8 @@ import com.divary.global.exception.ErrorCode;
 import com.divary.common.converter.TypeConverter;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -166,7 +168,7 @@ public class ChatRoomService {
     
     
     // 이미지 업로드 처리
-    private void processImageUpload(HashMap<String, Object> messageData, org.springframework.web.multipart.MultipartFile image, Long userId, String chatRoomId) {
+    private void processImageUpload(HashMap<String, Object> messageData, MultipartFile image, Long userId, String chatRoomId) {
         if (image != null && !image.isEmpty()) {
             ImageResponse imageResponse = imageService.uploadImageByType(
                 ImageType.USER_CHAT,

--- a/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
+++ b/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
@@ -9,7 +9,7 @@ import com.divary.domain.encyclopedia.entity.EncyclopediaCard;
 import com.divary.domain.encyclopedia.enums.Type;
 import com.divary.domain.encyclopedia.repository.EncyclopediaCardRepository;
 import com.divary.domain.image.dto.response.ImageResponse;
-import com.divary.domain.image.entity.ImageType;
+import com.divary.domain.image.enums.ImageType;
 import com.divary.domain.image.service.ImageService;
 import com.divary.global.exception.BusinessException;
 import com.divary.global.exception.ErrorCode;

--- a/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
+++ b/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
@@ -85,7 +85,7 @@ public class EncyclopediaCardService {
         List<String> imageUrls = imageService.getImagesByType(
                         ImageType.SYSTEM_DOGAM,
                         null,
-                        String.valueOf(card.getId())
+                        card.getId()
                 ).stream()
                 .map(ImageResponse::getFileUrl)
                 .toList();

--- a/src/main/java/com/divary/domain/image/controller/ImageController.java
+++ b/src/main/java/com/divary/domain/image/controller/ImageController.java
@@ -1,7 +1,6 @@
 package com.divary.domain.image.controller;
 
 import com.divary.common.response.ApiResponse;
-import com.divary.domain.image.dto.request.ImageUploadRequest;
 import com.divary.domain.image.dto.response.ImageResponse;
 import com.divary.domain.image.dto.response.MultipleImageUploadResponse;
 import com.divary.domain.image.entity.ImageType;
@@ -46,28 +45,6 @@ public class ImageController {
         
         MultipleImageUploadResponse response = imageService.uploadTempImages(files, userPrincipal.getId());
         return ApiResponse.success("임시 이미지 업로드가 완료되었습니다. 24시간 내에 사용하지 않으면 자동 삭제됩니다.", response);
-    }
-
-    @Operation(summary = "이미지 업로드", description = "S3에 이미지를 업로드하고 정보를 저장합니다.")
-    @ApiErrorExamples({
-            ErrorCode.VALIDATION_ERROR,
-            ErrorCode.INTERNAL_SERVER_ERROR
-    })
-    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<ImageResponse> uploadImage(
-            @Parameter(description = "업로드할 이미지 파일", required = true,
-                      content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
-            @RequestPart("file") MultipartFile file,
-            
-            @Parameter(description = "S3 업로드 경로", required = true, example = "users/1/chat/10/")
-            @RequestParam("uploadPath") String uploadPath) {
-        ImageUploadRequest request = ImageUploadRequest.builder()
-                .file(file)
-                .uploadPath(uploadPath)
-                .build();
-
-        ImageResponse response = imageService.uploadImage(request);
-        return ApiResponse.success("이미지 업로드가 완료되었습니다.", response);
     }
 
     @Operation(summary = "이미지 삭제", description = "S3와 DB에서 이미지를 삭제합니다.")

--- a/src/main/java/com/divary/domain/image/controller/ImageController.java
+++ b/src/main/java/com/divary/domain/image/controller/ImageController.java
@@ -90,14 +90,14 @@ public class ImageController {
             @Parameter(description = "사용자 ID (USER 타입의 경우 필수)", example = "1")
             @RequestParam(required = false) Long userId,
             
-            @Parameter(description = "추가 경로 (선택사항)", example = "additional/path")
-            @RequestParam(required = false) String additionalPath
+            @Parameter(description = "추가 경로 (선택사항)", example = "1")
+            @RequestParam(required = false) Long postId
     ) {
-        ImageResponse response = imageService.uploadImageByType(imageType, file, userId, additionalPath);
+        ImageResponse response = imageService.uploadImageByType(imageType, file, userId, postId);
         return ApiResponse.success("타입별 이미지 업로드가 완료되었습니다.", response);
     }
 
-    @Operation(summary = "이미지 타입별 상세 정보 조회", description = "ImageType을 기준으로 해당 타입의 이미지 상세 정보를 조회합니다.")
+    @Operation(summary = "이미지 타입별 상세 정보 조회", description = "ImageType을 기준으로 해당 타입의 이미지 상세 정보를 조회합니다. 시스템 타입은 추가 경로 없이 조회 가능합니다.")
     @ApiErrorExamples({
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.INTERNAL_SERVER_ERROR
@@ -108,10 +108,10 @@ public class ImageController {
             @PathVariable ImageType imageType,
             @Parameter(description = "사용자 ID (USER 타입의 경우 필수)", example = "1")
             @RequestParam(required = false) Long userId,
-            @Parameter(description = "추가 경로 (선택사항)", example = "additional/path")
-            @RequestParam(required = false) String additionalPath
+            @Parameter(description = "추가 경로 (선택사항)", example = "1")
+            @RequestParam(required = false) Long postId
     ) {
-        List<ImageResponse> images = imageService.getImagesByType(imageType, userId, additionalPath);
+        List<ImageResponse> images = imageService.getImagesByType(imageType, userId, postId);
         return ApiResponse.success("이미지 타입별 상세 정보를 조회했습니다.", images);
     }
 } 

--- a/src/main/java/com/divary/domain/image/controller/ImageController.java
+++ b/src/main/java/com/divary/domain/image/controller/ImageController.java
@@ -3,7 +3,7 @@ package com.divary.domain.image.controller;
 import com.divary.common.response.ApiResponse;
 import com.divary.domain.image.dto.response.ImageResponse;
 import com.divary.domain.image.dto.response.MultipleImageUploadResponse;
-import com.divary.domain.image.entity.ImageType;
+import com.divary.domain.image.enums.ImageType;
 import com.divary.domain.image.service.ImageService;
 import com.divary.global.config.security.CustomUserPrincipal;
 import com.divary.global.config.SwaggerConfig.ApiErrorExamples;

--- a/src/main/java/com/divary/domain/image/controller/ImageController.java
+++ b/src/main/java/com/divary/domain/image/controller/ImageController.java
@@ -25,7 +25,7 @@ import java.util.List;
 @Tag(name = "Image", description = "이미지 업로드 및 관리")
 @Slf4j
 @RestController
-@RequestMapping("images")
+@RequestMapping("/images")
 @RequiredArgsConstructor
 public class ImageController {
 

--- a/src/main/java/com/divary/domain/image/dto/response/ImageResponse.java
+++ b/src/main/java/com/divary/domain/image/dto/response/ImageResponse.java
@@ -1,7 +1,8 @@
 package com.divary.domain.image.dto.response;
 
 import com.divary.domain.image.entity.Image;
-import com.divary.domain.image.entity.ImageType;
+import com.divary.domain.image.enums.ImageType;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/divary/domain/image/entity/Image.java
+++ b/src/main/java/com/divary/domain/image/entity/Image.java
@@ -1,6 +1,8 @@
 package com.divary.domain.image.entity;
 
 import com.divary.common.entity.BaseEntity;
+import com.divary.domain.image.enums.ImageType;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/divary/domain/image/entity/Image.java
+++ b/src/main/java/com/divary/domain/image/entity/Image.java
@@ -40,14 +40,19 @@ public class Image extends BaseEntity {
     @Schema(description = "업로드한 사용자 ID", example = "1")
     private Long userId;
 
+    @Column(name = "post_id")
+    @Schema(description = "연결된 게시글 ID", example = "123")
+    private Long postId;
+
     @Builder
-    public Image(String s3Key, ImageType type, String originalFilename, Long width, Long height, Long userId) {
+    public Image(String s3Key, ImageType type, String originalFilename, Long width, Long height, Long userId, Long postId) {
         this.s3Key = s3Key;
         this.type = type;
         this.originalFilename = originalFilename;
         this.width = width;
         this.height = height;
         this.userId = userId;
+        this.postId = postId;
     }
 
     // 이미지 정보 업데이트
@@ -63,5 +68,10 @@ public class Image extends BaseEntity {
     // S3 키 업데이트
     public void updateS3Key(String s3Key) {
         this.s3Key = s3Key;
+    }
+
+    // 게시글 ID 업데이트 (temp → permanent 변환 시)
+    public void updatePostId(Long postId) {
+        this.postId = postId;
     }
 }

--- a/src/main/java/com/divary/domain/image/enums/ImageType.java
+++ b/src/main/java/com/divary/domain/image/enums/ImageType.java
@@ -1,4 +1,4 @@
-package com.divary.domain.image.entity;
+package com.divary.domain.image.enums;
 
 import lombok.Getter;
 

--- a/src/main/java/com/divary/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/divary/domain/image/repository/ImageRepository.java
@@ -25,4 +25,10 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     
     // S3 키가 특정 패턴으로 시작하는 이미지 목록 조회
     List<Image> findByS3KeyStartingWith(String s3KeyPrefix);
+    
+    // 특정 타입과 게시글 ID로 이미지 조회
+    List<Image> findByTypeAndPostId(ImageType type, Long postId);
+    
+    // postId가 null인 temp 이미지들 조회
+    List<Image> findByPostIdIsNull();
 } 

--- a/src/main/java/com/divary/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/divary/domain/image/repository/ImageRepository.java
@@ -1,7 +1,8 @@
 package com.divary.domain.image.repository;
 
 import com.divary.domain.image.entity.Image;
-import com.divary.domain.image.entity.ImageType;
+import com.divary.domain.image.enums.ImageType;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/divary/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/divary/domain/image/repository/ImageRepository.java
@@ -4,8 +4,11 @@ import com.divary.domain.image.entity.Image;
 import com.divary.domain.image.enums.ImageType;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,4 +35,8 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     
     // postId가 null인 temp 이미지들 조회
     List<Image> findByPostIdIsNull();
+    
+    // 24시간이 지난 temp 경로 고아 이미지들 조회 (postId가 null이고 생성일이 기준 시간 이전, temp 경로 포함)
+    @Query("SELECT i FROM Image i WHERE i.postId IS NULL AND i.createdAt < :cutoffTime AND i.s3Key LIKE '%/temp/%'")
+    List<Image> findOrphanedTempImages(@Param("cutoffTime") LocalDateTime cutoffTime);
 } 

--- a/src/main/java/com/divary/domain/image/service/ImageCleanupService.java
+++ b/src/main/java/com/divary/domain/image/service/ImageCleanupService.java
@@ -1,0 +1,143 @@
+package com.divary.domain.image.service;
+
+import com.divary.domain.image.entity.Image;
+import com.divary.domain.image.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageCleanupService {
+
+    private final ImageRepository imageRepository;
+    private final ImageStorageService imageStorageService;
+
+    /**
+     * 매일 한국시간 새벽 3시에 고아 이미지들을 삭제
+     * 1. DB의 고아 이미지: postId가 null이고 s3Key에 '/temp/' 경로가 포함되며 생성된 지 24시간이 지난 이미지
+     * 2. S3의 고아 파일: S3에는 있지만 DB에는 없는 temp 경로의 파일들
+     */
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void cleanupOrphanedImages() {
+        log.info("고아 이미지 삭제 작업을 시작합니다.");
+        
+        try {
+            // 1. DB의 temp 경로 고아 이미지들 삭제
+            cleanupDbOrphanedTempImages();
+            
+            // 2. S3의 고아 파일들 삭제
+            cleanupS3OrphanedFiles();
+            
+            log.info("고아 이미지 삭제 작업이 완료되었습니다.");
+            
+        } catch (Exception e) {
+            log.error("고아 이미지 삭제 작업 중 오류가 발생했습니다.", e);
+        }
+    }
+    
+    private void cleanupDbOrphanedTempImages() {
+        log.info("DB의 temp 경로 고아 이미지 삭제를 시작합니다.");
+        
+        // 24시간 전 시간 계산
+        LocalDateTime cutoffTime = LocalDateTime.now().minusHours(24);
+        log.info("삭제 기준 시간: {}", cutoffTime);
+        
+        // 삭제 대상 temp 경로 고아 이미지들 조회
+        List<Image> orphanedTempImages = imageRepository.findOrphanedTempImages(cutoffTime);
+        
+        if (orphanedTempImages.isEmpty()) {
+            log.info("삭제할 DB의 temp 경로 고아 이미지가 없습니다.");
+            return;
+        }
+        
+        log.info("{}개의 DB temp 경로 고아 이미지를 삭제합니다.", orphanedTempImages.size());
+        
+        int successCount = 0;
+        int failureCount = 0;
+        
+        // 각 이미지에 대해 S3와 DB에서 삭제
+        for (Image image : orphanedTempImages) {
+            try {
+                // S3에서 이미지 파일 삭제
+                imageStorageService.deleteFromS3(image.getS3Key());
+                
+                // DB에서 이미지 정보 삭제
+                imageRepository.delete(image);
+                
+                successCount++;
+                log.debug("DB temp 이미지 삭제 완료: ID={}, S3Key={}", image.getId(), image.getS3Key());
+                
+            } catch (Exception e) {
+                failureCount++;
+                log.error("DB temp 이미지 삭제 실패: ID={}, S3Key={}, 오류={}", 
+                        image.getId(), image.getS3Key(), e.getMessage(), e);
+            }
+        }
+        
+        log.info("DB temp 경로 고아 이미지 삭제가 완료되었습니다. 성공: {}개, 실패: {}개", successCount, failureCount);
+    }
+    
+    private void cleanupS3OrphanedFiles() {
+        log.info("S3 고아 파일 삭제를 시작합니다.");
+        
+        // S3에서 temp 경로의 모든 파일 목록 조회
+        String tempPrefix = "users/";
+        List<String> s3TempFiles = imageStorageService.listTempFiles(tempPrefix)
+                .stream()
+                .filter(key -> key.contains("/temp/"))
+                .toList();
+        
+        if (s3TempFiles.isEmpty()) {
+            log.info("S3에 temp 파일이 없습니다.");
+            return;
+        }
+        
+        log.info("S3에서 {}개의 temp 파일을 발견했습니다.", s3TempFiles.size());
+        
+        // DB에 존재하는 S3 키 목록 조회
+        Set<String> dbS3Keys = imageRepository.findAll()
+                .stream()
+                .map(Image::getS3Key)
+                .collect(Collectors.toSet());
+        
+        // S3에는 있지만 DB에는 없는 고아 파일들 찾기
+        List<String> orphanedS3Files = s3TempFiles.stream()
+                .filter(s3Key -> !dbS3Keys.contains(s3Key))
+                .toList();
+        
+        if (orphanedS3Files.isEmpty()) {
+            log.info("삭제할 S3 고아 파일이 없습니다.");
+            return;
+        }
+        
+        log.info("{}개의 S3 고아 파일을 삭제합니다.", orphanedS3Files.size());
+        
+        int successCount = 0;
+        int failureCount = 0;
+        
+        // S3에서 고아 파일들 삭제
+        for (String s3Key : orphanedS3Files) {
+            try {
+                imageStorageService.deleteFromS3(s3Key);
+                successCount++;
+                log.debug("S3 고아 파일 삭제 완료: {}", s3Key);
+                
+            } catch (Exception e) {
+                failureCount++;
+                log.error("S3 고아 파일 삭제 실패: S3Key={}, 오류={}", s3Key, e.getMessage(), e);
+            }
+        }
+        
+        log.info("S3 고아 파일 삭제가 완료되었습니다. 성공: {}개, 실패: {}개", successCount, failureCount);
+    }
+}

--- a/src/main/java/com/divary/domain/image/service/ImagePathService.java
+++ b/src/main/java/com/divary/domain/image/service/ImagePathService.java
@@ -1,10 +1,11 @@
 package com.divary.domain.image.service;
 
-import com.divary.domain.image.entity.ImageType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import com.divary.domain.image.enums.ImageType;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/com/divary/domain/image/service/ImagePathService.java
+++ b/src/main/java/com/divary/domain/image/service/ImagePathService.java
@@ -1,11 +1,29 @@
 package com.divary.domain.image.service;
 
 import com.divary.domain.image.entity.ImageType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
 @Service
-// 이미지 경로 생성 서비스
+@RequiredArgsConstructor
 public class ImagePathService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+    
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    private static Pattern tempUrlPattern = null;
 
     // 유저 이미지 업로드 경로 생성
     public String generateUserUploadPath(ImageType imageType, Long userId, String additionalPath) {
@@ -42,6 +60,14 @@ public class ImagePathService {
         return path.toString();
     }
 
+    // temp 경로 생성
+    public String generateTempPath(Long userId) {
+        validateUserId(userId);
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        String randomId = UUID.randomUUID().toString().substring(0, 8);
+        return String.format("users/%d/temp/%s_%s", userId, timestamp, randomId);
+    }
+
     // 경로에서 사용자 ID 추출
     public Long extractUserIdFromPath(String uploadPath) {
         if (uploadPath != null && uploadPath.startsWith("users/")) {
@@ -55,6 +81,81 @@ public class ImagePathService {
             }
         }
         return null;
+    }
+
+    // temp 이미지 URL 패턴 생성
+    public String getTempImageUrlPattern() {
+        return getS3ImageUrlPattern("users/\\d+/temp/.*?");
+    }
+
+    // 모든 이미지 URL 패턴 생성 (temp + permanent)
+    public String getAllImageUrlPattern() {
+        return getS3ImageUrlPattern("[^\\\\s\"'<>]+");
+    }
+
+    // 본문에서 temp 이미지 URL 패턴 추출
+    public List<String> extractTempImageUrls(String content) {
+        if (tempUrlPattern == null) {
+            String pattern = getTempImageUrlPattern();
+            log.info("temp URL 정규식 패턴: {}", pattern);
+            tempUrlPattern = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+        }
+        
+        log.info("컨텐츠에서 temp URL 추출 시도: {}", content);
+        
+        Matcher matcher = tempUrlPattern.matcher(content);
+        List<String> tempUrls = new ArrayList<>();
+        while (matcher.find()) {
+            String foundUrl = matcher.group();
+            tempUrls.add(foundUrl);
+            log.info("temp URL 발견: {}", foundUrl);
+        }
+        
+        log.info("총 발견된 temp URL 개수: {}", tempUrls.size());
+        return tempUrls;
+    }
+
+    // 컨텐츠에서 모든 이미지 URL 추출 (temp 이미지뿐만 아니라 permanent 이미지도)
+    public List<String> extractAllImageUrls(String content) {
+        if (content == null || content.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+        
+        String allImagePattern = getAllImageUrlPattern();
+        Pattern pattern = Pattern.compile(allImagePattern, Pattern.CASE_INSENSITIVE);
+        
+        Matcher matcher = pattern.matcher(content);
+        List<String> imageUrls = new ArrayList<>();
+        while (matcher.find()) {
+            imageUrls.add(matcher.group());
+        }
+        
+        log.debug("컨텐츠에서 추출된 이미지 URL 개수: {}", imageUrls.size());
+        return imageUrls;
+    }
+
+    // 본문의 temp URL을 permanent URL로 교체
+    public String replaceTempUrls(String content, Map<String, String> urlMappings) {
+        String result = content;
+        for (Map.Entry<String, String> entry : urlMappings.entrySet()) {
+            result = result.replace(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
+
+    // temp 경로 이미지인지 확인
+    public boolean isTempImage(String s3Key) {
+        return s3Key != null && s3Key.contains("/temp/");
+    }
+
+    // S3 이미지 URL 패턴 생성 
+    private String getS3ImageUrlPattern(String pathPattern) {
+        return String.format(
+            "https://%s\\.s3\\.%s\\.amazonaws\\.com/%s\\.(jpg|jpeg|png|gif|webp)",
+            java.util.regex.Pattern.quote(bucketName),
+            java.util.regex.Pattern.quote(region),
+            pathPattern
+        );
     }
 
     private void validateUserImageType(ImageType imageType) {

--- a/src/main/java/com/divary/domain/image/service/ImageService.java
+++ b/src/main/java/com/divary/domain/image/service/ImageService.java
@@ -370,6 +370,11 @@ public class ImageService {
         }
     }
     
+    // postId로 이미지 목록 조회
+    public List<Image> findByTypeAndPostId(ImageType imageType, Long postId) {
+        return imageRepository.findByTypeAndPostId(imageType, postId);
+    }
+    
     // 컨텐츠에서 모든 이미지 URL 추출 (temp 이미지뿐만 아니라 permanent 이미지도)
     private List<String> extractAllImageUrls(String content) {
         if (content == null || content.trim().isEmpty()) {

--- a/src/main/java/com/divary/domain/image/service/ImageService.java
+++ b/src/main/java/com/divary/domain/image/service/ImageService.java
@@ -4,7 +4,7 @@ import com.divary.domain.image.dto.request.ImageUploadRequest;
 import com.divary.domain.image.dto.response.ImageResponse;
 import com.divary.domain.image.dto.response.MultipleImageUploadResponse;
 import com.divary.domain.image.entity.Image;
-import com.divary.domain.image.entity.ImageType;
+import com.divary.domain.image.enums.ImageType;
 import com.divary.domain.image.repository.ImageRepository;
 import com.divary.global.exception.BusinessException;
 import com.divary.global.exception.ErrorCode;

--- a/src/main/java/com/divary/domain/image/service/ImageStorageService.java
+++ b/src/main/java/com/divary/domain/image/service/ImageStorageService.java
@@ -125,13 +125,37 @@ public class ImageStorageService {
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, s3Key);
     }
 
-    // 현재 S3 설정에 맞는 temp 이미지 URL 패턴 생성
-    public String getTempImageUrlPattern() {
+    // S3 이미지 URL 패턴 생성 (공통 베이스 메서드)
+    private String getS3ImageUrlPattern(String pathPattern) {
         return String.format(
-            "https://%s\\.s3\\.%s\\.amazonaws\\.com/users/\\d+/temp/.*?\\.(jpg|jpeg|png|gif|webp)",
+            "https://%s\\.s3\\.%s\\.amazonaws\\.com/%s\\.(jpg|jpeg|png|gif|webp)",
             java.util.regex.Pattern.quote(bucketName),
-            java.util.regex.Pattern.quote(region)
+            java.util.regex.Pattern.quote(region),
+            pathPattern
         );
+    }
+
+    // temp 이미지 URL 패턴 생성
+    public String getTempImageUrlPattern() {
+        return getS3ImageUrlPattern("users/\\\\d+/temp/.*?");
+    }
+
+    // 모든 이미지 URL 패턴 생성 (temp + permanent)
+    public String getAllImageUrlPattern() {
+        return getS3ImageUrlPattern("[^\\\\s\"'<>]+");
+    }
+
+    // S3 URL에서 S3 키 추출
+    public String extractS3KeyFromUrl(String imageUrl) {
+        try {
+            String[] parts = imageUrl.split(".amazonaws.com/", 2);
+            if (parts.length == 2) {
+                return parts[1];
+            }
+            throw new IllegalArgumentException("Invalid S3 URL format: " + imageUrl);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to extract S3 key from URL: " + imageUrl, e);
+        }
     }
 
     // 고유한 파일명 생성

--- a/src/main/java/com/divary/domain/image/service/ImageStorageService.java
+++ b/src/main/java/com/divary/domain/image/service/ImageStorageService.java
@@ -40,7 +40,7 @@ public class ImageStorageService {
                     .build();
 
             s3Client.putObject(putObjectRequest, 
-                              RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+                            RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
             
             log.info("S3 업로드 완료: {}", s3Key);
         } catch (IOException e) {
@@ -125,25 +125,6 @@ public class ImageStorageService {
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, s3Key);
     }
 
-    // S3 이미지 URL 패턴 생성 
-    private String getS3ImageUrlPattern(String pathPattern) {
-        return String.format(
-            "https://%s\\.s3\\.%s\\.amazonaws\\.com/%s\\.(jpg|jpeg|png|gif|webp)",
-            java.util.regex.Pattern.quote(bucketName),
-            java.util.regex.Pattern.quote(region),
-            pathPattern
-        );
-    }
-
-    // temp 이미지 URL 패턴 생성
-    public String getTempImageUrlPattern() {
-        return getS3ImageUrlPattern("users/\\d+/temp/.*?");
-    }
-
-    // 모든 이미지 URL 패턴 생성 (temp + permanent)
-    public String getAllImageUrlPattern() {
-        return getS3ImageUrlPattern("[^\\\\s\"'<>]+");
-    }
 
     // S3 URL에서 S3 키 추출
     public String extractS3KeyFromUrl(String imageUrl) {

--- a/src/main/java/com/divary/domain/image/service/ImageValidationService.java
+++ b/src/main/java/com/divary/domain/image/service/ImageValidationService.java
@@ -1,6 +1,7 @@
 package com.divary.domain.image.service;
 
 import com.divary.domain.image.dto.request.ImageUploadRequest;
+import com.divary.domain.image.entity.ImageType;
 import com.divary.global.exception.BusinessException;
 import com.divary.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +48,24 @@ public class ImageValidationService {
         String contentType = file.getContentType();
         if (contentType == null || !contentType.startsWith("image/")) {
             throw new BusinessException(ErrorCode.IMAGE_FORMAT_NOT_SUPPORTED);
+        }
+    }
+
+    public void validateUserImageType(ImageType imageType) {
+        if (!imageType.name().startsWith("USER_")) {
+            throw new IllegalArgumentException("USER 타입 이미지만 처리 가능합니다: " + imageType);
+        }
+    }
+
+    public void validateSystemImageType(ImageType imageType) {
+        if (!imageType.name().startsWith("SYSTEM_")) {
+            throw new IllegalArgumentException("SYSTEM 타입 이미지만 처리 가능합니다: " + imageType);
+        }
+    }
+
+    public void validateUserId(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("사용자 ID는 필수입니다.");
         }
     }
 

--- a/src/main/java/com/divary/domain/image/service/ImageValidationService.java
+++ b/src/main/java/com/divary/domain/image/service/ImageValidationService.java
@@ -1,7 +1,7 @@
 package com.divary.domain.image.service;
 
 import com.divary.domain.image.dto.request.ImageUploadRequest;
-import com.divary.domain.image.entity.ImageType;
+import com.divary.domain.image.enums.ImageType;
 import com.divary.global.exception.BusinessException;
 import com.divary.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/divary/domain/image/service/ImageValidationService.java
+++ b/src/main/java/com/divary/domain/image/service/ImageValidationService.java
@@ -1,0 +1,63 @@
+package com.divary.domain.image.service;
+
+import com.divary.domain.image.dto.request.ImageUploadRequest;
+import com.divary.global.exception.BusinessException;
+import com.divary.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageValidationService {
+
+    private static final int MAX_FILES_PER_UPLOAD = 10;
+    private static final long MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+    public void validateUploadRequest(ImageUploadRequest request) {
+        validateFile(request.getFile());
+        validateUploadPath(request.getUploadPath());
+    }
+
+    public void validateMultipleFiles(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            throw new BusinessException(ErrorCode.REQUIRED_FIELD_MISSING);
+        }
+        
+        if (files.size() > MAX_FILES_PER_UPLOAD) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        
+        files.forEach(this::validateFile);
+    }
+
+    public void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.REQUIRED_FIELD_MISSING);
+        }
+        
+        if (file.getSize() > MAX_FILE_SIZE_BYTES) {
+            throw new BusinessException(ErrorCode.IMAGE_SIZE_TOO_LARGE);
+        }
+        
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new BusinessException(ErrorCode.IMAGE_FORMAT_NOT_SUPPORTED);
+        }
+    }
+
+    private void validateUploadPath(String uploadPath) {
+        if (uploadPath == null || uploadPath.trim().isEmpty()) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
+        
+        // 경로 보안 검증 (../ 등 상위 디렉토리 접근 차단)
+        if (uploadPath.contains("..") || uploadPath.startsWith("/")) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/divary/domain/logbook/entity/LogBaseInfo.java
+++ b/src/main/java/com/divary/domain/logbook/entity/LogBaseInfo.java
@@ -27,6 +27,7 @@ public class LogBaseInfo extends BaseEntity {
     private Member member;
 
     @OneToMany(mappedBy = "logBaseInfo", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @Builder.Default
     private List<LogBook> logBooks = new ArrayList<>();
 
     @Column(name = "name", nullable = false, length = 40)
@@ -45,6 +46,7 @@ public class LogBaseInfo extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "save_status",nullable = false)
     @Schema(description = "저장 상태", example = "COMPLETE")
+    @Builder.Default
     private SaveStatus saveStatus = SaveStatus.COMPLETE;
 
     public void updateName(String name) {

--- a/src/main/java/com/divary/domain/system/controller/SystemController.java
+++ b/src/main/java/com/divary/domain/system/controller/SystemController.java
@@ -139,7 +139,7 @@ public class SystemController {
                 testContent, 
                 ImageType.USER_TEST_POST, 
                 userId, 
-                String.valueOf(boardId)
+                boardId
         );
         
         log.info("변환된 컨텐츠: {}", processedContent);

--- a/src/main/java/com/divary/domain/system/controller/SystemController.java
+++ b/src/main/java/com/divary/domain/system/controller/SystemController.java
@@ -5,7 +5,7 @@ import com.divary.domain.Member.entity.Member;
 import com.divary.domain.Member.enums.Role;
 import com.divary.domain.Member.repository.MemberRepository;
 import com.divary.common.enums.SocialType;
-import com.divary.domain.image.entity.ImageType;
+import com.divary.domain.image.enums.ImageType;
 import com.divary.domain.image.service.ImageService;
 import com.divary.global.config.SwaggerConfig.ApiErrorExamples;
 import com.divary.global.config.security.jwt.JwtTokenProvider;

--- a/src/main/java/com/divary/domain/system/controller/SystemController.java
+++ b/src/main/java/com/divary/domain/system/controller/SystemController.java
@@ -21,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collections;

--- a/src/main/java/com/divary/global/exception/ErrorCode.java
+++ b/src/main/java/com/divary/global/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_001", "이미지 업로드에 실패했습니다."),
     IMAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "IMAGE_002", "이미지 크기와 용량이 너무 큽니다."),
     IMAGE_FORMAT_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "IMAGE_003", "지원하지 않는 이미지 형식입니다."),
+    IMAGE_URL_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "IMAGE_004", "올바르지 않은 이미지 URL 형식입니다."),
     
     // 인증 관련 에러코드 강화
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "토큰이 유효하지 않습니다."),


### PR DESCRIPTION
## 🔗 관련 이슈
#80 

---

## 📌 PR 요약
1. 이미지 서비스에서 너무 많은 책임을 지고 있기에 역할별로 분리를 진행했습니다. 역할은 다믕과 같습니다.
    - ImageService: 핵심 비즈니스 로직
    - ImageStorageService: S3 파일 조작 전담
    - ImagePathService: 경로 생성 및 URL 처리
    - ImageValidationService: 입력값 검증 통합
    
2. 엔티티 및 Enum 변경 사항들
    - ImageType을 entity → enums 패키지로 이동 했습ㄴ디다.
    - Image 엔티티에 postId 필드 추가했는데 이는 글을 업데이트하면 추적하지 못하는 상황에 대해서 고아 이미지 파일을 삭제할 방법이 없기에  어쩔 수 없이 추가했습니다.
    - 메서드 파라미터 타입을 String에서 Long으로 변환했으며 이제는 addtionalPath에 해당 게시글 아이디를 받는 것으로 동작합니다. 
    
3. 이미지 서비스 메서드 추가
    - 이미지 업로드는 IOS에서 담당하는 것이고 `POST [/api/v1/images/upload/temp]`를 써서 이미지 url로 변환 -> 이미지 url과 게시글 내용과 함께 전달 -> 백엔드는 게시글 내용들을 그대로 `processContentAndUpdateImages`에 파라미터로 넣으면 영구 경로로 변환합니다.