### PR TITLE
fix: ImageService 변경에 따른 호출부 코드 수정

### DIFF
--- a/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
+++ b/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
@@ -55,7 +55,7 @@ public class EncyclopediaCardService {
         }
 
         // 모든 도감 프로필 (도감 이모티콘) 한 번에 조회
-        List<ImageResponse> allDogamProfiles = imageService.getImagesByType(ImageType.SYSTEM_DOGAM_PROFILE, null, null);
+        List<ImageResponse> allDogamProfiles = imageService.getImagesByType(ImageType.SYSTEM_DOGAM_PROFILE, null, 0L);
 
         // cardId -> FileUrl 매핑
         Map<Long, String> dogamProfileMap = allDogamProfiles.stream()


### PR DESCRIPTION
## 🔗 관련 이슈
#92 
---

## 📌 PR 요약

기존 ImageService.getImagesByType() 메서드는 String additionalPath를 인자로 받았으나,
<img width="852" height="304" alt="스크린샷 2025-08-06 오후 9 57 07" src="https://github.com/user-attachments/assets/945ddd01-06a9-4358-8be7-2de9434ba5ad" />

코드 변경 후 Long postId를 인자로 받도록 수정되었습니다.
<img width="939" height="318" alt="스크린샷 2025-08-06 오후 9 56 56" src="https://github.com/user-attachments/assets/6acaaaf8-5a21-4126-84a7-34fece4e0473" />


해양도감 조회 API에서는 이미 S3에 저장된 썸네일 이미지 전체를 조회만 하기 때문에 postId가 존재하지 않습니다.
따라서 기존 코드에서 null을 인자로 넘기던 부분이 postId.toString() 호출 시 NPE 가 발생하게 됩니다. 
<img width="1067" height="94" alt="스크린샷 2025-08-06 오후 10 17 49" src="https://github.com/user-attachments/assets/9469c0fc-d3da-4fd3-87b5-e78cc750c576" />

0L을 넘겨 "조회 전용 경로"임을 명시해주었습니다.
<img width="1133" height="103" alt="스크린샷 2025-08-06 오후 10 22 46" src="https://github.com/user-attachments/assets/d6c3e797-ef1d-4938-85f9-71760f2fb1e8" />


## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1. EncyclopediaCardService 내 getImagesByType() 호출부 수정

---

## 스크린샷 (선택)
<img width="1171" height="680" alt="스크린샷 2025-08-06 오후 10 16 30" src="https://github.com/user-attachments/assets/8311b8c3-ff7d-42a8-b220-34723463eca3" />

<img width="1093" height="688" alt="스크린샷 2025-08-06 오후 10 16 41" src="https://github.com/user-attachments/assets/2d30b153-87e0-4278-8eb0-385796954a8a" />

<img width="1165" height="677" alt="스크린샷 2025-08-06 오후 10 17 06" src="https://github.com/user-attachments/assets/231b5609-1b30-4ddd-814e-4cd20d30a20f" />

---

## 💡 추가 참고 사항
도감 썸네일은 반드시 아래와 같은 경로로 업로드 되어야 합니다.
system/dogam/profile/0/{cardId}/thumbnail.png

### < SYSTEM_DOGAM_PROFILE >
한 번에 전체 조회함 (postId=0L)

경로: system/dogam/profile/0/{cardId}/...

### < SYSTEM_DOGAM >
cardId별로 조회함 (postId=cardId)

경로: system/dogam/{cardId}/...

