### PR TITLE
fix/#94:로그북 put request dto 수정

### DIFF
--- a/src/main/java/com/divary/domain/logbase/logbook/dto/request/LogDetailPutRequestDTO.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/dto/request/LogDetailPutRequestDTO.java
@@ -25,9 +25,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LogDetailPutRequestDTO {
 
-    @Schema(description = "로그북베이스정보 id")
-    private Long logBaseInfoId;
-
     @Schema(description = "다이빙 날짜", example = "2025-07-25")
     private LocalDate date;
 

--- a/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
@@ -182,8 +182,7 @@ public class LogBookService {
         logBook.setSight(dto.getSight());
 
 
-        LogBaseInfo base = logBaseInfoRepository.findById(dto.getLogBaseInfoId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.LOG_BASE_NOT_FOUND));
+        LogBaseInfo base = logBook.getLogBaseInfo();
 
         if (dto.getSaveStatus() == SaveStatus.TEMP){
             base.setSaveStatus(SaveStatus.TEMP);


### PR DESCRIPTION
## 🔗 관련 이슈

#94 
---

## 📌 PR 요약

디테일 로그북 put request dto에서 logBaseInfoId 컬럼을 삭제,
서비스에서도 logbook을 통해서 logBaseInfo에 접근하도록 함

---

## 📑 작업 내용



---

## 스크린샷 (선택)


---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
