### PR TITLE
fix: 도감 카드 목록 조회 시 이미지가 누락되는 문제 해결

### DIFF
--- a/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
+++ b/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -44,27 +45,43 @@ public class EncyclopediaCardService {
     @Transactional(readOnly = true)
     public List<EncyclopediaCardSummaryResponse> getCards(String description) {
         List<EncyclopediaCard> cards;
-        if (description == null) {
-            cards = encyclopediaCardRepository.findAll();
-        } else {
-            if (!isValidDescription(description)) {
-                throw new BusinessException(ErrorCode.TYPE_NOT_FOUND);
-            }
+        if (description == null) cards = encyclopediaCardRepository.findAll();
+
+        else {
+            if (!isValidDescription(description)) throw new BusinessException(ErrorCode.TYPE_NOT_FOUND);
             Type typeEnum = convertDescriptionToEnum(description);
             cards = encyclopediaCardRepository.findAllByType(typeEnum);
         }
 
-        // 모든 도감 프로필 (도감 이모티콘) 한 번에 조회
-        List<ImageResponse> allDogamProfiles = imageService.getImagesByType(ImageType.SYSTEM_DOGAM_PROFILE, null, 0L);
+        // 도감 프로필 전부 불러오기
+        String pathPattern = "system/dogam_profile/";
+        List<ImageResponse> allProfileImages = imageService.getImagesByPath(pathPattern);
 
-        // cardId -> FileUrl 매핑
-        Map<Long, String> dogamProfileMap = allDogamProfiles.stream()
-                .collect(
-                        Collectors.toMap(img ->
-                                Long.valueOf(img.getS3Key().split("/")[2]),
-                                ImageResponse::getFileUrl,
-                                (v1, v2) -> v1 ) // 혹시라도 동일 cardId에 도감 프로필이 여러 개 있을 경우, 첫 번째 값만 사용
-                );
+        Map<Long, String> profileImageMap;
+        if (description == null) {
+            // 필터링이 없을 때
+            profileImageMap = allProfileImages.stream()
+                    .filter(image -> image.getPostId() != null)
+                    .collect(Collectors.toMap(
+                            ImageResponse::getPostId,
+                            ImageResponse::getFileUrl,
+                            (existingUrl, newUrl) -> existingUrl
+                    ));
+        } else {
+            // 필터링이 있을 때: 조회된 카드 ID 목록을 먼저 추출
+            Set<Long> cardIds = cards.stream()
+                    .map(EncyclopediaCard::getId)
+                    .collect(Collectors.toSet());
+
+            // 해당 카드 ID를 가진 이미지들만 필터링하여
+            profileImageMap = allProfileImages.stream()
+                    .filter(image -> image.getPostId() != null && cardIds.contains(image.getPostId()))
+                    .collect(Collectors.toMap(
+                            ImageResponse::getPostId,
+                            ImageResponse::getFileUrl,
+                            (existingUrl, newUrl) -> existingUrl
+                    ));
+        }
 
         return cards.stream()
                 .map(card ->
@@ -72,7 +89,7 @@ public class EncyclopediaCardService {
                                 .id(card.getId())
                                 .name(card.getName())
                                 .type(card.getType().getDescription())
-                                .dogamProfileUrl(dogamProfileMap.get(card.getId()))
+                                .dogamProfileUrl(profileImageMap.get(card.getId()))
                                 .build())
                 .toList();
     }

--- a/src/main/java/com/divary/domain/image/controller/ImageController.java
+++ b/src/main/java/com/divary/domain/image/controller/ImageController.java
@@ -47,6 +47,30 @@ public class ImageController {
         return ApiResponse.success("임시 이미지 업로드가 완료되었습니다. 24시간 내에 사용하지 않으면 자동 삭제됩니다.", response);
     }
 
+    @Operation(summary = "시스템 이미지 업로드", description = "지정된 타입과 postId에 연결되는 시스템 이미지를 1개 업로드합니다.")
+    @ApiErrorExamples({
+            ErrorCode.REQUIRED_FIELD_MISSING,
+            ErrorCode.IMAGE_SIZE_TOO_LARGE,
+            ErrorCode.IMAGE_FORMAT_NOT_SUPPORTED,
+            ErrorCode.AUTHENTICATION_REQUIRED
+    })
+    @PostMapping(value = "/upload/system", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ImageResponse> uploadSystemImage(
+            @Parameter(description = "업로드할 이미지 파일 (1개)", required = true)
+            @RequestPart("file") MultipartFile file,
+
+            @Parameter(description = "이미지의 용도 (예: SYSTEM_DOGAM_PROFILE)", required = true)
+            @RequestParam("imageType") ImageType imageType,
+
+            @Parameter(description = "이미지를 연결할 부모 엔티티의 ID (예: 도감 카드 ID)", required = true)
+            @RequestParam("postId") Long postId,
+
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal) { // 시스템 이미지 업로드 권한 확인용
+
+        ImageResponse response = imageService.uploadSystemImage(imageType, file, postId);
+        return ApiResponse.success("시스템 이미지가 성공적으로 업로드되었습니다.", response);
+    }
+
     @Operation(summary = "이미지 삭제", description = "S3와 DB에서 이미지를 삭제합니다.")
     @ApiErrorExamples({
             ErrorCode.INTERNAL_SERVER_ERROR

--- a/src/main/java/com/divary/domain/image/dto/response/ImageResponse.java
+++ b/src/main/java/com/divary/domain/image/dto/response/ImageResponse.java
@@ -46,6 +46,9 @@ public class ImageResponse {
 
     @Schema(description = "S3 저장 키", example = "system/dogam_profile/1/filename.jpg")
     private String s3Key;
+
+    @Schema(description = "연결된 게시글(카드) ID", example = "123")
+    private Long postId;
     
     public static ImageResponse from(Image image, String fileUrl) {
         return ImageResponse.builder()
@@ -59,6 +62,7 @@ public class ImageResponse {
                 .updatedAt(image.getUpdatedAt())
                 .userId(image.getUserId())
                 .s3Key(image.getS3Key())
+                .postId(image.getPostId())
                 .build();
     }
 } 

--- a/src/main/java/com/divary/domain/image/service/ImageService.java
+++ b/src/main/java/com/divary/domain/image/service/ImageService.java
@@ -268,8 +268,26 @@ public class ImageService {
         Image savedImage = imageRepository.findById(response.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
         savedImage.updateType(imageType);
-        
+
         // 업데이트된 이미지로 응답 생성
+        return ImageResponse.from(savedImage, response.getFileUrl());
+    }
+
+    @Transactional
+    public ImageResponse uploadSystemImage(ImageType imageType, MultipartFile file, Long postId) {
+        String uploadPath = imagePathService.generateSystemUploadPath(imageType, postId.toString());
+
+        ImageUploadRequest request = ImageUploadRequest.builder()
+                .file(file)
+                .uploadPath(uploadPath)
+                .build();
+
+        ImageResponse response = uploadImage(request);
+
+        Image savedImage = imageRepository.findById(response.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+        savedImage.updateType(imageType);
+        savedImage.updatePostId(postId);
         return ImageResponse.from(savedImage, response.getFileUrl());
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
#95 
---

## 📌 PR 요약

PR에 대한 간략한 설명을 작성해주세요.  
시스템 이미지 업로드용 컨트롤러와 서비스 메서드를 추가하여 이미지 저장 시 postId를 기록하도록 수정했습니다.

---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1. POST /api/v1/images/upload/system 를 추가했습니다.

2. uploadSystemImage 메서드에 postId를 DB에 저장하는 로직(updatePostId)을 추가했습니다 ( 이미지와 도감 카드 간의 매핑 )

3.  ImageResponse DTO에 postId 필드를 추가했습니다.

4. Image 테이블에서 모든 프로필 이미지를 한 번에 가져오고, 
```
String pathPattern = "system/dogam_profile/"
List<ImageResponse>allProfileImages=imageService.getImagesByPath(pathPattern);
```
EncyclopediaCard 테이블에서는 사용자가 요청한 종류(예: 어류)로 필터링된 카드 목록을 조회합니다. 그 다음, 카드의 고유 id와 이미지의 postId가 일치하는 쌍을 찾아 매핑해주는 방식으로 수정했습니다.

---

## 스크린샷 (선택)
<img width="922" height="811" alt="스크린샷 2025-08-08 오전 2 21 17" src="https://github.com/user-attachments/assets/1c1957c5-d023-4beb-9dad-3a63ed1ecb2f" />

<img width="924" height="750" alt="스크린샷 2025-08-08 오전 2 20 54" src="https://github.com/user-attachments/assets/dcfa43f7-e7f4-426c-a45d-c36629d60e97" />

---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
