### PR TITLE
fix: 다이어리 저장 시 임시 이미지가 영구 전환되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/divary/domain/image/entity/Image.java
+++ b/src/main/java/com/divary/domain/image/entity/Image.java
@@ -22,7 +22,7 @@ public class Image extends BaseEntity {
     private String s3Key;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type")
+    @Column(name = "type", length = 50)
     @Schema(description = "이미지 타입", example = "DOGAM")
     private ImageType type;
 

--- a/src/main/java/com/divary/domain/image/enums/ImageType.java
+++ b/src/main/java/com/divary/domain/image/enums/ImageType.java
@@ -8,6 +8,7 @@ public enum ImageType {
     USER_DIVING_LOG,
     USER_CHAT,
     USER_LICENSE,
+    USER_DIARY,
     
     // 테스트용 이미지 타입
     USER_TEST_POST,

--- a/src/main/java/com/divary/domain/logbase/logdiary/controller/DiaryController.java
+++ b/src/main/java/com/divary/domain/logbase/logdiary/controller/DiaryController.java
@@ -52,7 +52,7 @@ public class DiaryController {
             ErrorCode.DIARY_FORBIDDEN_ACCESS
     })
     public ApiResponse<DiaryResponse> updateDiary(
-            @Parameter(description = "하나의 logBaseInfo당 하나의 diary가 매핑됩니다. diary 생성시 logBaseInfoId를 보내주세요.") @PathVariable  Long logBaseInfoId,
+            @Parameter(description = "하나의 logBaseInfo당 하나의 diary가 매핑됩니다. diary 생성시 logBaseInfoId를 보내주세요. 수정시 본문에 '유지할 기존 이미지의 영구 URL'과 '새로 추가한 이미지의 temp URL'을 모두 포함한 최종본을 보내주세요.") @PathVariable  Long logBaseInfoId,
             @RequestBody DiaryRequest request, @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
         return ApiResponse.success(diaryService.updateDiary(userPrincipal.getId(), logBaseInfoId, request));
     }

--- a/src/main/java/com/divary/domain/logbase/logdiary/dto/DiaryResponse.java
+++ b/src/main/java/com/divary/domain/logbase/logdiary/dto/DiaryResponse.java
@@ -3,8 +3,10 @@ package com.divary.domain.logbase.logdiary.dto;
 import com.divary.domain.logbase.logdiary.entity.Diary;
 import com.divary.global.exception.BusinessException;
 import com.divary.global.exception.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
@@ -17,17 +19,20 @@ public class DiaryResponse {
     private Long logId;
     private List<Map<String, Object>> contents;
 
-    public static DiaryResponse from(Diary diary) {
-        ObjectMapper objectMapper = new ObjectMapper();
+    public static DiaryResponse from(Diary diary, String processedContentJson, ObjectMapper objectMapper) {
         List<Map<String, Object>> contents;
-        try {
-            contents = objectMapper.readValue(
-                    diary.getContentJson(),
-                    new TypeReference<>() {
-                    }
-            );
-        } catch (Exception e) {
-            throw new BusinessException(ErrorCode.INVALID_JSON_FORMAT);
+        if (processedContentJson == null || processedContentJson.trim().isEmpty()) {
+            contents = Collections.emptyList();
+        } else {
+            try {
+                contents = objectMapper.readValue(
+                        processedContentJson,
+                        new TypeReference<>() {
+                        }
+                );
+            } catch (JsonProcessingException e) {
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return DiaryResponse.builder()

--- a/src/main/java/com/divary/domain/logbase/logdiary/service/DiaryService.java
+++ b/src/main/java/com/divary/domain/logbase/logdiary/service/DiaryService.java
@@ -1,5 +1,6 @@
 package com.divary.domain.logbase.logdiary.service;
 
+import com.divary.domain.image.service.ImageService;
 import com.divary.domain.logbase.LogBaseInfo;
 import com.divary.domain.logbase.LogBaseInfoService;
 import com.divary.domain.logbase.logdiary.dto.DiaryRequest;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.divary.domain.image.enums.ImageType;
 
 @Slf4j
 @Service
@@ -23,39 +25,65 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final LogBaseInfoService logBaseInfoService;
     private final ObjectMapper objectMapper;
+    private final ImageService imageService;
 
     @Transactional
     public DiaryResponse createDiary(Long userId, Long logBaseInfoId, DiaryRequest request) {
         // 로그베이스의 존재와 접근 권한 확인
         LogBaseInfo logBaseInfo = logBaseInfoService.validateAccess(logBaseInfoId, userId);
 
-        // 이후 다이어리 중복 여부 확인
+        // 이후 다이어리 중복 여부 확인 JSON
         if (diaryRepository.existsByLogBaseInfoId(logBaseInfoId)) {
             throw new BusinessException(ErrorCode.DIARY_ALREADY_EXISTS);
         }
 
+        // 이미지 임시 url이 포함된 contents을 JSON 문자열로 변환
         String contentJson = toJson(request.getContents());
+
+        // ImageService를 호출하여 이미지 처리 및 영구 URL로 교체된 JSON 받기
+        String processedContentJson = imageService.processContentAndUpdateImages(
+                contentJson,
+                ImageType.USER_DIARY,
+                userId,
+                logBaseInfoId,
+                null                  // 이전 콘텐츠 (생성이므로 null)
+        );
         Diary diary = Diary.builder()
                 .logBaseInfo(logBaseInfo)
-                .contentJson(contentJson)
+                .contentJson(processedContentJson)
                 .build();
 
         diaryRepository.save(diary);
-        return DiaryResponse.from(diary);
+        return DiaryResponse.from(diary, processedContentJson, objectMapper);
     }
 
     @Transactional
     public DiaryResponse updateDiary(Long userId, Long logBaseInfoId, DiaryRequest request) {
         Diary diary = getDiaryWithAuth(logBaseInfoId, userId);
-        String contentJson = toJson(request.getContents());
-        diary.updateContent(contentJson);
-        return DiaryResponse.from(diary);
+        // DB에 저장된 기존 콘텐츠 (삭제된 이미지를 찾기 위함)
+        String previousContentJson = diary.getContentJson();
+
+        // 요청받은 새 컨텐츠를 JSON 문자열로 변환
+        String newContentJson = toJson(request.getContents());
+
+        // ImageService를 호출하여 이미지 추가/삭제 처리 및 최종 JSON 받기
+        String processedContentJson = imageService.processContentAndUpdateImages(
+                newContentJson,
+                ImageType.USER_DIARY,
+                userId,
+                logBaseInfoId,
+                previousContentJson     // 이전 콘텐츠
+        );
+
+        diary.updateContent(processedContentJson);
+        return DiaryResponse.from(diary, processedContentJson, objectMapper);
+
     }
 
     @Transactional(readOnly = true)
     public DiaryResponse getDiary(Long userId, Long logBaseInfoId) {
         Diary diary = getDiaryWithAuth(logBaseInfoId, userId);
-        return DiaryResponse.from(diary);
+        return DiaryResponse.from(diary, diary.getContentJson(), objectMapper);
     }
 
     private String toJson(Object contents) {


### PR DESCRIPTION
## 🔗 관련 이슈
#100 

---

## 📌 PR 요약
사용자가 이미지를 올리다 이탈하거나 이미지를 삭제했을 때, 사용되지 않는 이미지가 데이터베이스와 스토리지에 그대로 남는 문제를 해결하고자 시(temp) URL을 우선 만들고 본문은 post 할때 영구 URL로 전환하는 로직이 추가됨

-> 이에 따라 DiaryService의 코드 수정이 필요해졌다.

---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1. DiaryService에 ImageService 의존성 주입
2. createDiary 수정
3. updateDiary 로직 수정

---

## 스크린샷 (선택)
### 1. 사용자가 다이어리 작성 중 이미지를 선택하는 상황 
**API 호출**  : POST /api/v1/images/upload/temp
**서버 응답**  : 임시 URL

<img width="1050" height="836" alt="스크린샷 2025-08-08 오후 3 31 24" src="https://github.com/user-attachments/assets/ce09fb41-0eb1-4306-97d0-d40ab14675d7" />


### 2. 서버로부터 받은 임시 URL을 다이어리 본문(Content)에 넣어 다이어리 저장 버튼을 누르는 상황
**API 호출** : POST /api/v1/logs/{logBaseInfoId}/diary
**전송 데이터** : 다이어리 제목, 날씨 등과 함께 임시 이미지 URL이 포함된 본문 전체
**서버 응답** :  영구 URL

<img width="995" height="537" alt="스크린샷 2025-08-08 오후 3 33 07" src="https://github.com/user-attachments/assets/6e87fba9-05ee-4bc4-889a-e3419ae6663f" />
<img width="1167" height="436" alt="스크린샷 2025-08-08 오후 3 33 57" src="https://github.com/user-attachments/assets/b95c2438-464b-42b2-99fa-90ac1846bcf4" />

### 3. 다이어리를 수정하는 상황 
**전송 데이터** : 임시 URL과 영구URL이 포함된 본문 전체
**서버 응답**  : 영구 URL

<img width="980" height="414" alt="스크린샷 2025-08-08 오후 4 39 36" src="https://github.com/user-attachments/assets/75b2b11f-e206-4c76-ba2d-428427b27e32" />
<img width="975" height="372" alt="스크린샷 2025-08-08 오후 4 39 44" src="https://github.com/user-attachments/assets/faedfe50-ffb9-496f-864d-0e93008019be" />



---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
