### PR TITLE
fix: 도감 상세 조회 이미지 경로 오류 수정 및 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Desktop.ini
 ### Logs ###
 *.log
 logs/
+nohup.out
 
 ### Runtime data ###
 pids

--- a/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
+++ b/src/main/java/com/divary/domain/encyclopedia/service/EncyclopediaCardService.java
@@ -9,7 +9,6 @@ import com.divary.domain.encyclopedia.entity.EncyclopediaCard;
 import com.divary.domain.encyclopedia.enums.Type;
 import com.divary.domain.encyclopedia.repository.EncyclopediaCardRepository;
 import com.divary.domain.image.dto.response.ImageResponse;
-import com.divary.domain.image.enums.ImageType;
 import com.divary.domain.image.service.ImageService;
 import com.divary.global.exception.BusinessException;
 import com.divary.global.exception.ErrorCode;
@@ -99,11 +98,10 @@ public class EncyclopediaCardService {
         EncyclopediaCard card = encyclopediaCardRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
 
-        List<String> imageUrls = imageService.getImagesByType(
-                        ImageType.SYSTEM_DOGAM,
-                        null,
-                        card.getId()
-                ).stream()
+        String pathPattern = "system/dogam/" + id + "/";
+
+        List<String> imageUrls = imageService.getImagesByPath(pathPattern)
+                .stream()
                 .map(ImageResponse::getFileUrl)
                 .toList();
 


### PR DESCRIPTION
## 🔗 관련 이슈

연관된 이슈 번호를 적어주세요. (예: #123)
#105 
---

## 📌 PR 요약
prod환경에서 해양 도감 데이터를 입력하던 중, 특정 도감의 상세 정보를 조회할 때 연관 없는 다른 도감의 이미지가 함께 조회되는 버그를 수정했습니다.

특정 ID(예: 1)의 이미지를 조회하면, 해당 ID로 시작하는 다른 모든 ID(예: 10, 11)의 이미지가 함께 출력되는 문제 
<img width="789" height="351" alt="스크린샷 2025-08-09 오전 10 44 12" src="https://github.com/user-attachments/assets/5087afe8-103a-444f-b7c8-3e1d0875fe3c" />

---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1.  imageService.getImagesByType -> imageService.getImagesByPath 
---

## 스크린샷 (선택)
기존
<img width="1019" height="370" alt="스크린샷 2025-08-09 오전 10 29 44" src="https://github.com/user-attachments/assets/fc83a853-914d-4b43-9a2b-3b151124ac04" />

수정 후 
<img width="886" height="639" alt="스크린샷 2025-08-09 오전 10 30 43" src="https://github.com/user-attachments/assets/37a07f5a-260a-4975-b93f-387560bf8a4a" />

---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
