### PR TITLE
Fix/#112 : 로그북 조회시 null 값 반환 처리

### DIFF
--- a/src/main/java/com/divary/domain/logbase/logbook/dto/response/LogBaseCreateResultDTO.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/dto/response/LogBaseCreateResultDTO.java
@@ -25,9 +25,6 @@ public class LogBaseCreateResultDTO {
     @Schema(description = "아이콘 타입", example = "CLOWNFISH")
     private IconType iconType;
 
-    @Schema(description = "누적 횟수")
-    private int accumulation;
-
     @Schema(description = "로그북베이스 id")
     private Long LogBaseInfoId;
 

--- a/src/main/java/com/divary/domain/logbase/logbook/dto/response/LogBookDetailResultDTO.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/dto/response/LogBookDetailResultDTO.java
@@ -8,7 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Builder
 @Getter
@@ -21,8 +23,8 @@ public class LogBookDetailResultDTO {
     private String icon;
     private LocalDate date;
 
-    private SaveStatus saveStatus;
-    private int accumulation;
+    private String saveStatus;
+    private Integer accumulation;
 
     private String place;
     private String divePoint;
@@ -33,54 +35,55 @@ public class LogBookDetailResultDTO {
 
     private String suitType;
     private String equipment;
-    private int weight;
+    private Integer weight;
     private String perceivedWeight;
 
     private String weather;
     private String wind;
     private String tide;
     private String wave;
-    private int temperature;
-    private int waterTemperature;
+    private Integer temperature;
+    private Integer waterTemperature;
     private String perceivedTemp;
     private String sight;
 
-    private int diveTime;
-    private int maxDepth;
-    private int avgDepth;
-    private int decompressDepth;
-    private int decompressTime;
-    private int startPressure;
-    private int finishPressure;
-    private int consumption;
+    private Integer diveTime;
+    private Integer maxDepth;
+    private Integer avgDepth;
+    private Integer decompressDepth;
+    private Integer decompressTime;
+    private Integer startPressure;
+    private Integer finishPressure;
+    private Integer consumption;
 
     public static LogBookDetailResultDTO from(LogBook logBook, List<Companion> companions) {
         return LogBookDetailResultDTO.builder()
                 .LogBookId(logBook.getId())
                 .name(logBook.getLogBaseInfo().getName())
                 .icon(logBook.getLogBaseInfo().getIconType().name())
-                .saveStatus(logBook.getSaveStatus())
+                .saveStatus(Optional.ofNullable(logBook.getSaveStatus()).map(Enum::name).orElse(null))
                 .accumulation(logBook.getAccumulation())
                 .date(logBook.getLogBaseInfo().getDate())
                 .place(logBook.getPlace())
                 .divePoint(logBook.getDivePoint())
-                .diveMethod(logBook.getDiveMethod().name())
-                .divePurpose(logBook.getDivePurpose().name())
-                .companions(companions.stream()
+                .diveMethod(Optional.ofNullable(logBook.getDiveMethod()).map(Enum::name).orElse(null))
+                .divePurpose(Optional.ofNullable(logBook.getDivePurpose()).map(Enum::name).orElse(null))
+                .companions(Optional.ofNullable(companions).orElse(Collections.emptyList())
+                        .stream()
                         .map(CompanionResultDTO::from)
                         .toList())
-                .suitType(logBook.getSuitType().name())
+                .suitType(Optional.ofNullable(logBook.getSuitType()).map(Enum::name).orElse(null))
                 .equipment(logBook.getEquipment())
                 .weight(logBook.getWeight())
-                .perceivedWeight(logBook.getPerceivedWeight().name())
-                .weather(logBook.getWeatherType().name())
-                .wind(logBook.getWind().name())
-                .tide(logBook.getTide().name())
-                .wave(logBook.getWave().name())
+                .perceivedWeight(Optional.ofNullable(logBook.getPerceivedWeight()).map(Enum::name).orElse(null))
+                .weather(Optional.ofNullable(logBook.getWeatherType()).map(Enum::name).orElse(null))
+                .wind(Optional.ofNullable(logBook.getWind()).map(Enum::name).orElse(null))
+                .tide(Optional.ofNullable(logBook.getTide()).map(Enum::name).orElse(null))
+                .wave(Optional.ofNullable(logBook.getWave()).map(Enum::name).orElse(null))
                 .temperature(logBook.getTemperature())
                 .waterTemperature(logBook.getWaterTemperature())
-                .perceivedTemp(logBook.getPerceivedTemp().name())
-                .sight(logBook.getSight().name())
+                .perceivedTemp(Optional.ofNullable(logBook.getPerceivedTemp()).map(Enum::name).orElse(null))
+                .sight(Optional.ofNullable(logBook.getSight()).map(Enum::name).orElse(null))
                 .diveTime(logBook.getDiveTime())
                 .maxDepth(logBook.getMaxDepth())
                 .avgDepth(logBook.getAvgDepth())
@@ -91,4 +94,5 @@ public class LogBookDetailResultDTO {
                 .consumption(logBook.getConsumption())
                 .build();
     }
+
 }

--- a/src/main/java/com/divary/domain/logbase/logbook/entity/LogBook.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/entity/LogBook.java
@@ -58,7 +58,7 @@ public class LogBook extends BaseEntity {
 
     @Column(name = "accumulation",nullable = false)
     @Schema(description = "누적 횟수", example = "3")
-    private int accumulation;
+    private Integer accumulation;
 
     @Column(name = "place",length = 50)
     @Schema(description = "다이빙 지역", example = "제주도 서귀포시")

--- a/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
@@ -49,14 +49,10 @@ public class LogBookService {
 
         LogBaseInfo saved = logBaseInfoRepository.save(logBaseInfo);
 
-        int accumulation = logBookRepository.countByLogBaseInfoMember(member)+1;
-        //그동안의 로그북 누적횟수 세기
-
         return LogBaseCreateResultDTO.builder()
                 .name(saved.getName())
                 .iconType(saved.getIconType())
                 .date(saved.getDate())
-                .accumulation(accumulation)
                 .LogBaseInfoId(saved.getId())
                 .build();
     }


### PR DESCRIPTION
## 🔗 관련 이슈

#112 
---

## 📌 PR 요약

로그북 조회시 컬럼에 null 값이 있으면 NPE가 발생합니다. 
null값인 enum 컬럼에서 name()을 호출할 때, null인 companions 리스트에 접근할 때 해당 오류가 발생하는 것을 확인했습니다.
따라서 조회 dto에서 optional을 활용하여 null safe하게 조회할 수 있도록 처리하였습니다.

---

## 📑 작업 내용

1. 조회 dto에서 int를 integer로 수정하고, 
2. dto 빌더에서 optional을 활용하였습니다

---

## 스크린샷 (선택)
<img width="1946" height="1403" alt="image" src="https://github.com/user-attachments/assets/09e20e74-7f6f-406e-b047-925b840434ab" />


---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
