### PR TITLE
refac/#118: 누적횟수 계산 로직 변경

### DIFF
--- a/src/main/java/com/divary/domain/logbase/logbook/controller/LogBookController.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/controller/LogBookController.java
@@ -41,6 +41,7 @@ public class LogBookController {
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal)
     {
         Long userId = userPrincipal.getId();
+
         LogBaseCreateResultDTO responseDto = logBookService.createLogBase(createDTO, userId);
         return ApiResponse.success(responseDto);
     }
@@ -55,6 +56,7 @@ public class LogBookController {
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
 
         Long userId = userPrincipal.getId();
+
         List<LogBaseListResultDTO> result = logBookService.getLogBooksByYearAndStatus(year, saveStatus, userId);
         return ApiResponse.success(result);
     }
@@ -64,8 +66,12 @@ public class LogBookController {
     @ApiErrorExamples(value = {ErrorCode.LOG_NOT_FOUND, ErrorCode.LOG_BASE_NOT_FOUND, ErrorCode.AUTHENTICATION_REQUIRED})
     @Operation(summary = "로그 상세조회", description = "특정 로그북의 상세 정보를 조회합니다.")
     public ApiResponse<List<LogBookDetailResultDTO>> getLogDetail
-            (@PathVariable Long logBaseInfoId) {
-        List<LogBookDetailResultDTO> resultDTOS = logBookService.getLogDetail(logBaseInfoId);
+            (@PathVariable Long logBaseInfoId,
+             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+
+        Long userId = userPrincipal.getId();
+
+        List<LogBookDetailResultDTO> resultDTOS = logBookService.getLogDetail(logBaseInfoId,userId);
         return ApiResponse.success(resultDTOS);
     }
 
@@ -76,7 +82,9 @@ public class LogBookController {
     public ApiResponse<LogDetailCreateResultDTO> createLogDetail
             (@PathVariable Long logBaseInfoId,
              @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+
         Long userId = userPrincipal.getId();
+
         LogDetailCreateResultDTO result = logBookService.createLogDetail(logBaseInfoId, userId);
         return ApiResponse.success(result);
     }
@@ -88,7 +96,9 @@ public class LogBookController {
     public ApiResponse<Void> deleteLogBase
             (@PathVariable @Valid Long logBaseInfoId,
              @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+
         Long userId= userPrincipal.getId();
+
         logBookService.deleteLog(logBaseInfoId, userId);
         return ApiResponse.success(null);
     }
@@ -116,6 +126,7 @@ public class LogBookController {
             @RequestBody @Valid LogNameUpdateRequestDTO dto){
 
         Long userId = userPrincipal.getId();
+
         logBookService.updateLogName(logBaseInfoId, userId, dto.getName());
         return ApiResponse.success(null);
     }

--- a/src/main/java/com/divary/domain/logbase/logbook/dto/response/LogBookDetailResultDTO.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/dto/response/LogBookDetailResultDTO.java
@@ -56,13 +56,13 @@ public class LogBookDetailResultDTO {
     private Integer finishPressure;
     private Integer consumption;
 
-    public static LogBookDetailResultDTO from(LogBook logBook, List<Companion> companions) {
+    public static LogBookDetailResultDTO from(LogBook logBook, List<Companion> companions, Integer accumulation) {
         return LogBookDetailResultDTO.builder()
                 .LogBookId(logBook.getId())
                 .name(logBook.getLogBaseInfo().getName())
                 .icon(logBook.getLogBaseInfo().getIconType().name())
                 .saveStatus(Optional.ofNullable(logBook.getSaveStatus()).map(Enum::name).orElse(null))
-                .accumulation(logBook.getAccumulation())
+                .accumulation(accumulation)
                 .date(logBook.getLogBaseInfo().getDate())
                 .place(logBook.getPlace())
                 .divePoint(logBook.getDivePoint())

--- a/src/main/java/com/divary/domain/logbase/logbook/entity/LogBook.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/entity/LogBook.java
@@ -56,10 +56,6 @@ public class LogBook extends BaseEntity {
     @Schema(description = "각 로그북의 저장 상태", example = "TEMP")
     private SaveStatus saveStatus;
 
-    @Column(name = "accumulation",nullable = false)
-    @Schema(description = "누적 횟수", example = "3")
-    private Integer accumulation;
-
     @Column(name = "place",length = 50)
     @Schema(description = "다이빙 지역", example = "제주도 서귀포시")
     private String place;

--- a/src/main/java/com/divary/domain/logbase/logbook/repository/LogBookRepository.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/repository/LogBookRepository.java
@@ -13,7 +13,7 @@ public interface LogBookRepository extends JpaRepository<LogBook,Long> {
     List<LogBook> findByLogBaseInfo(LogBaseInfo logBaseInfo);
     //로그베이스정보로 로그북들 찾기
 
-    int countByLogBaseInfoMemberAndSaveStatus(Member member, SaveStatus saveStatus);
+    int countByLogBaseInfoMemberIdAndSaveStatus(Long memberId, SaveStatus saveStatus);
 
     int countByLogBaseInfo(LogBaseInfo logBaseInfo);
 

--- a/src/main/java/com/divary/domain/logbase/logbook/repository/LogBookRepository.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/repository/LogBookRepository.java
@@ -1,5 +1,6 @@
 package com.divary.domain.logbase.logbook.repository;
 
+import com.divary.domain.logbase.logbook.enums.SaveStatus;
 import com.divary.domain.member.entity.Member;
 import com.divary.domain.logbase.LogBaseInfo;
 import com.divary.domain.logbase.logbook.entity.LogBook;
@@ -12,7 +13,7 @@ public interface LogBookRepository extends JpaRepository<LogBook,Long> {
     List<LogBook> findByLogBaseInfo(LogBaseInfo logBaseInfo);
     //로그베이스정보로 로그북들 찾기
 
-    int countByLogBaseInfoMember(Member member);
+    int countByLogBaseInfoMemberAndSaveStatus(Member member, SaveStatus saveStatus);
 
     int countByLogBaseInfo(LogBaseInfo logBaseInfo);
 

--- a/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
@@ -84,7 +84,7 @@ public class LogBookService {
     }//연도에 따라, 저장 상태(임시저장,완전저장)에 따라 로그북베이스정보 조회
 
     @Transactional
-    public List<LogBookDetailResultDTO> getLogDetail(Long logBaseInfoId) {
+    public List<LogBookDetailResultDTO> getLogDetail(Long logBaseInfoId, Long userId) {
 
         LogBaseInfo logBaseInfo = logBaseInfoRepository.findById(logBaseInfoId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.LOG_BASE_NOT_FOUND));
@@ -95,11 +95,16 @@ public class LogBookService {
             throw new BusinessException(ErrorCode.LOG_NOT_FOUND);
         }
 
+        Member member = memberService.findById(userId);
+        Integer accumulation
+                = logBookRepository.countByLogBaseInfoMemberAndSaveStatus(member,SaveStatus.COMPLETE);
+        //현재기준으로 총 로그북 누적횟수 계산
+
         // 각 로그북에 대해 companion 함께 매핑하여 DTO 변환
         return logBooks.stream()
                 .map(logBook -> {
                     List<Companion> companions = companionRepository.findByLogBook(logBook);
-                    return LogBookDetailResultDTO.from(logBook, companions);
+                    return LogBookDetailResultDTO.from(logBook, companions, accumulation);
                 })
                 .collect(Collectors.toList());
     }
@@ -115,13 +120,8 @@ public class LogBookService {
             throw new BusinessException(ErrorCode.LOG_LIMIT_EXCEEDED);
         }//하루 최대 3개 넘으면 에러 던지기
 
-        Member member = memberService.findById(userId);
-        int accumulation = logBookRepository.countByLogBaseInfoMember(member)+1;
-        //누적횟수 계산
-
         LogBook logBook = LogBook.builder()
                 .logBaseInfo(base)
-                .accumulation(accumulation)
                 .build();
 
         logBookRepository.save(logBook);

--- a/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
@@ -95,9 +95,8 @@ public class LogBookService {
             throw new BusinessException(ErrorCode.LOG_NOT_FOUND);
         }
 
-        Member member = memberService.findById(userId);
         Integer accumulation
-                = logBookRepository.countByLogBaseInfoMemberAndSaveStatus(member,SaveStatus.COMPLETE);
+                = logBookRepository.countByLogBaseInfoMemberIdAndSaveStatus(userId,SaveStatus.COMPLETE);
         //현재기준으로 총 로그북 누적횟수 계산
 
         // 각 로그북에 대해 companion 함께 매핑하여 DTO 변환


### PR DESCRIPTION
## 🔗 관련 이슈

#118 
---

## 📌 PR 요약

로그북 누적횟수 계산 로직을 변경하였습니다.

---

## 📑 작업 내용

1. 로그북 누적횟수 계산 시점을 create에서 get으로 변경
2. complete(완전저장)된 로그북만 카운트, 현재기준 총 로그북 개수가 되도록 고정
3. 로그북 엔티티 누적횟수 컬럼은 삭제

---

## 스크린샷 (선택)
<img width="2029" height="1209" alt="image" src="https://github.com/user-attachments/assets/49f4affa-e5d7-4646-b9d5-450ddb07ef4f" />


---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
