### PR TITLE
Docs/#169 ngnix dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ node_modules/
 .env.test.local
 .env.production.local
 
+
 ### Application specific ###
 application-dev.yml
 application-prod.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+# docker-compose.yml
+version: '3.8'
+
+services:
+  app:
+    build: .
+    env_file:
+      - .env # 로컬에서는 .env 파일을 사용
+
+  web:
+    build: ./nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - app
+    volumes:
+      - /etc/ssl/certs/divary.pem:/etc/ssl/certs/divary.pem:ro
+      - /etc/ssl/private/divary.key:/etc/ssl/private/divary.key:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,26 @@
-# docker-compose.yml
-version: '3.8'
+version: "3.9"
 
 services:
   app:
     build: .
+    container_name: app
+    ports:
+      - "8081:8080"
     env_file:
-      - .env # 로컬에서는 .env 파일을 사용
+      - .env
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
 
   web:
     build: ./nginx
+    container_name: web
     ports:
-      - "80:80"
-      - "443:443"
+      # 서버의 8888 포트를 컨테이너의 80(HTTP) 포트로 연결합니다.
+      - "8888:80"
+      # 서버의 8443 포트를 컨테이너의 443(HTTPS) 포트로 연결합니다.
+      - "8443:443"
     depends_on:
       - app
     volumes:
-      - /etc/ssl/certs/divary.pem:/etc/ssl/certs/divary.pem:ro
-      - /etc/ssl/private/divary.key:/etc/ssl/private/divary.key:ro
+      - ./nginx/certs/divary.pem:/etc/ssl/certs/divary.pem:ro
+      - ./nginx/certs/divary.key:/etc/ssl/private/divary.key:ro

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+# Nginx 공식 최신 이미지를 기반으로 시작
+FROM nginx:latest
+
+# 로컬에 있는 nginx.conf 파일을 컨테이너의 설정 폴더로 복사
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,25 @@
+# HTTP (80 포트) 요청을 HTTPS로 리디렉션
+server {
+    listen 80;
+    server_name divary.app www.divary.app;
+    return 301 https://$server_name$request_uri;
+}
+
+# HTTPS (443 포트) 요청 처리
+server {
+    listen 443 ssl;
+    server_name divary.app www.divary.app;
+
+    # SSL 인증서 경로. docker-compose에서 추후에 연결해줌.
+    ssl_certificate /etc/ssl/certs/divary.pem;
+    ssl_certificate_key /etc/ssl/private/divary.key;
+
+    location / {
+        #  localhost 대신 Spring Boot 컨테이너의 서비스 이름('app')을 사용
+        proxy_pass http://app:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,21 +1,19 @@
-# HTTP (80 포트) 요청을 HTTPS로 리디렉션
+# HTTP -> HTTPS redirect
 server {
     listen 80;
     server_name divary.app www.divary.app;
     return 301 https://$server_name$request_uri;
 }
 
-# HTTPS (443 포트) 요청 처리
+# HTTPS
 server {
     listen 443 ssl;
     server_name divary.app www.divary.app;
 
-    # SSL 인증서 경로. docker-compose에서 추후에 연결해줌.
     ssl_certificate /etc/ssl/certs/divary.pem;
     ssl_certificate_key /etc/ssl/private/divary.key;
 
     location / {
-        #  localhost 대신 Spring Boot 컨테이너의 서비스 이름('app')을 사용
         proxy_pass http://app:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/src/main/java/com/divary/domain/member/enums/Level 2.java
+++ b/src/main/java/com/divary/domain/member/enums/Level 2.java
@@ -1,0 +1,10 @@
+package com.divary.domain.Member.enums;
+
+public enum Level {
+    LEVEL_1,
+    LEVEL_2,
+    LEVEL_3,
+    LEVEL_4,
+    LEVEL_5,
+    LEVEL_6
+}


### PR DESCRIPTION
## 🔗 관련 이슈

#169 

---

## 📌 PR 요약

Docker 기반의 CI/CD 파이프라인을 구축했습니다.

### 현재 상황
- 운영 서버의 80/443 포트는 기존 nginx가 사용 중 → 컨테이너 테스트는 **임시 포트(8888/8443)** 로 진행 중
- 이후 운영 nginx를 내리고 컨테이너 nginx로 교체 예정

---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1. CI/CD 워크플로우 수정 (ECR 이미지 빌드/푸시 + EC2 배포)
2. Spring Boot 와 Nginx  별도의 컨테이너 환경 구성
3. nginx.conf 작성 (리버스 프록시 + SSL)
4. docker-compose.yml 작성 (app, web 컨테이너)
5. AWS ECR 리포지토리 생성 완료

---

## 스크린샷 (선택)


---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
