### PR TITLE
fix/#198: 탈퇴 복구 플로우 수정 - 소셜 토큰 기반 복구 구현

### DIFF
--- a/src/main/java/com/divary/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/divary/global/config/jwt/JwtAuthenticationFilter.java
@@ -36,8 +36,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtResolver jwtResolver;
     private final TokenBlackListService tokenBlackListService;
     private final MemberService memberService;
-    private static final String REACTIVATE_MEMBER_URI = "/api/v1/auth/reactivate";
-    private static final String REACTIVATE_MEMBER_METHOD = "POST"; //todo 하드코딩 안하게 변경
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -58,12 +56,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 Member member = memberService.findById(userId);
 
-                // 1. 현재 요청이 회원 복구 API인지 확인합니다.
-                boolean isRecoveryRequest = request.getRequestURI().equals(REACTIVATE_MEMBER_URI) &&
-                        request.getMethod().equalsIgnoreCase(REACTIVATE_MEMBER_METHOD);
-
-                // 2. 복구 요청이 아닌 경우에만 비활성화 상태를 체크합니다.
-                if (!isRecoveryRequest && member.getStatus() == Status.DEACTIVATED) {
+                // 탈퇴 신청된 계정은 API 접근 차단
+                if (member.getStatus() == Status.DEACTIVATED) {
                     throw new BusinessException(ErrorCode.MEMBER_IS_DEACTIVATE);
                 }
 

--- a/src/main/java/com/divary/global/exception/ErrorCode.java
+++ b/src/main/java/com/divary/global/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     DEVICE_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE_001", "디바이스 아이디를 찾을 수 없습니다"),
     MEMBER_IS_DEACTIVATE(HttpStatus.FORBIDDEN, "MEMBER_004", "탈퇴 예정인 계정입니다."),
     CONCURRENT_REQUEST_ERROR(HttpStatus.CONFLICT, "MEMBER_005", "탈퇴 요청 처리 중 데이터 충돌이 발생했습니다"),
+    MEMBER_NOT_DEACTIVATED(HttpStatus.BAD_REQUEST, "MEMBER_006", "탈퇴 신청되지 않은 계정입니다."),
     //소셜 로그인 관련
     GOOGLE_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "GOOGLE_001", "구글 유저를 찾을 수 없습니다"),
 

--- a/src/main/java/com/divary/global/oauth/controller/OauthController.java
+++ b/src/main/java/com/divary/global/oauth/controller/OauthController.java
@@ -94,14 +94,16 @@ public class OauthController {
         return ApiResponse.success(response);
     }
 
-    @PostMapping(value = "/reactivate")
-    @Operation(summary = "회원 탈퇴를 취소합니다.")
+    @PostMapping(value = "/{socialLoginType}/reactivate")
+    @Operation(summary = "소셜 토큰을 사용하여 회원 탈퇴를 취소합니다.")
     @ApiSuccessResponse(dataType = void.class)
-    @ApiErrorExamples(value = {ErrorCode.MEMBER_NOT_FOUND})
-    public ApiResponse reactivate(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
-        Long userId = userPrincipal.getId();
+    @ApiErrorExamples(value = {ErrorCode.EMAIL_NOT_FOUND, ErrorCode.MEMBER_NOT_DEACTIVATED})
+    public ApiResponse reactivate(@PathVariable(name = "socialLoginType") SocialType socialLoginType,
+                                   @Valid @RequestBody com.divary.global.oauth.dto.request.RecoveryRequestDto recoveryRequestDto) {
+        String accessToken = recoveryRequestDto.getAccessToken();
+        log.info(">> 복구 요청 - 소셜 타입: {}, accessToken: {}", socialLoginType, accessToken);
 
-        memberService.cancelDeleteMember(userId);
+        oauthService.reactivate(socialLoginType, accessToken);
         return ApiResponse.success("회원 정보 복구에 성공했습니다");
     }
 

--- a/src/main/java/com/divary/global/oauth/dto/request/RecoveryRequestDto.java
+++ b/src/main/java/com/divary/global/oauth/dto/request/RecoveryRequestDto.java
@@ -1,0 +1,12 @@
+package com.divary.global.oauth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RecoveryRequestDto {
+    @NotBlank(message = "access 토큰은 필수 입력 값입니다.")
+    private String accessToken;
+}

--- a/src/main/java/com/divary/global/oauth/service/OauthService.java
+++ b/src/main/java/com/divary/global/oauth/service/OauthService.java
@@ -56,6 +56,15 @@ public class OauthService {
         socialOauth.logout(deviceId, userId);
     }
 
+    @Transactional
+    public void reactivate(SocialType socialLoginType, String accessToken) {
+        SocialOauth socialOauth = this.findSocialOauthByType(socialLoginType);
+        if (socialOauth == null) {
+            throw new BusinessException(ErrorCode.SOCIAL_PROVIDER_NOT_FOUND);
+        }
+        socialOauth.reactivate(accessToken);
+    }
+
     /**
      * 우리 서비스의 Refresh Token을 사용하여 Access Token과 Refresh Token을 재발급합니다. (RTR)
      * 이 로직은 모든 소셜 로그인 사용자에게 공통으로 적용됩니다.

--- a/src/main/java/com/divary/global/oauth/service/social/AppleOauth.java
+++ b/src/main/java/com/divary/global/oauth/service/social/AppleOauth.java
@@ -9,6 +9,7 @@ import com.divary.domain.device_session.service.DeviceSessionService;
 import com.divary.global.config.jwt.JwtTokenProvider;
 import com.divary.global.config.security.CustomUserPrincipal;
 import com.divary.global.exception.BusinessException;
+import com.divary.global.exception.ErrorCode;
 import com.divary.global.oauth.dto.response.LoginResponseDTO;
 import com.divary.global.oauth.infra.AppleJwtParser;
 import com.divary.global.redis.service.TokenBlackListService;
@@ -50,6 +51,11 @@ public class AppleOauth implements SocialOauth {
 
         Member member = memberService.findOrCreateMember(email);
 
+        // 탈퇴 신청된 계정은 로그인 차단
+        if (member.getStatus() == Status.DEACTIVATED) {
+            throw new BusinessException(ErrorCode.MEMBER_IS_DEACTIVATE);
+        }
+
         CustomUserPrincipal principal = new CustomUserPrincipal(member);
 
         Authentication authentication = new UsernamePasswordAuthenticationToken(
@@ -78,6 +84,28 @@ public class AppleOauth implements SocialOauth {
 
         log.debug("Apple 계정 로그아웃 처리 완료. UserId: {}, DeviceId: {}", userId, deviceId);
     }
+
+    @Override
+    @Transactional
+    public void reactivate(String identityToken) {
+        // Identity Token을 검증하고 사용자 정보를 추출합니다.
+        Map<String, String> userInfo = appleJwtParser.parse(identityToken);
+        String email = userInfo.get("email");
+
+        // 이메일로 회원 찾기
+        Member member = memberService.findMemberByEmail(email);
+
+        // 탈퇴 신청된 계정이 아니면 복구 불가
+        if (member.getStatus() != Status.DEACTIVATED) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_DEACTIVATED);
+        }
+
+        // 복구 처리
+        memberService.cancelDeleteMember(member.getId());
+
+        log.debug("Apple 계정 복구 완료. Email: {}, UserId: {}", email, member.getId());
+    }
+
     @Override
     public SocialType getType() {
         return SocialType.APPLE;

--- a/src/main/java/com/divary/global/oauth/service/social/SocialOauth.java
+++ b/src/main/java/com/divary/global/oauth/service/social/SocialOauth.java
@@ -6,6 +6,7 @@ import com.divary.global.oauth.dto.response.LoginResponseDTO;
 public interface SocialOauth {
     LoginResponseDTO verifyAndLogin(String token, String deviceId);
     void logout(String deviceId, Long userId);
+    void reactivate(String token);
     SocialType getType();
 
 }


### PR DESCRIPTION


## 🔗 관련 이슈

연관된 이슈 번호를 적어주세요. (예: #123)
#198 
---

## 📌 PR 요약

탈퇴 복구 플로우 수정 - 소셜 토큰 기반 복구 구현

---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1. 탈퇴 신청 시 로그인 차단 로직 추가 (GoogleOauth, AppleOauth)
2. JWT 대신 소셜 access token으로 복구 요청 처리
3. 소셜 제공자에서 사용자 정보 재검증 후 복구 처리
4. 기존 JWT 기반 복구 예외 처리 제거 (JwtAuthenticationFilter)
5. 새로운 복구 엔드포인트: POST /auth/{socialLoginType}/reactivate
6. MEMBER_NOT_DEACTIVATED 에러 코드 추가

---

## 스크린샷 (선택)


---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
