### PR TITLE
fix/#200: Apple/Google 소셜 로그인을 socialId 기반으로 변경

### DIFF
--- a/src/main/java/com/divary/domain/member/entity/Member.java
+++ b/src/main/java/com/divary/domain/member/entity/Member.java
@@ -20,11 +20,21 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"socialId", "socialType"})
+})
 public class Member extends BaseEntity {
 
 
     @Column(nullable = false, unique = true)
     private String email;
+
+    @Column(nullable = true)
+    private String socialId;  // Apple sub 또는 Google sub
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private SocialType socialType;  // APPLE, GOOGLE 등
 
     @Enumerated(EnumType.STRING)
     @NotNull
@@ -61,5 +71,10 @@ public class Member extends BaseEntity {
     public void updateGroup(String newGroup){
         this.memberGroup = newGroup;
     }
-    
+
+    // 소셜 정보 업데이트 (기존 회원 마이그레이션용)
+    public void updateSocialInfo(String socialId, SocialType socialType) {
+        this.socialId = socialId;
+        this.socialType = socialType;
+    }
 }

--- a/src/main/java/com/divary/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/divary/domain/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.divary.domain.member.repository;
 
+import com.divary.common.enums.SocialType;
 import com.divary.domain.member.entity.Member;
 import com.divary.domain.member.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +12,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findById(Long id);
+    Optional<Member> findBySocialIdAndSocialType(String socialId, SocialType socialType);
     List<Member> findByStatusAndDeactivatedAtBefore(Status status, LocalDateTime cutoffDate);
 }

--- a/src/main/java/com/divary/domain/member/service/MemberService.java
+++ b/src/main/java/com/divary/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.divary.domain.member.service;
 
+import com.divary.common.enums.SocialType;
 import com.divary.domain.member.dto.requestDTO.MyPageGroupRequestDTO;
 import com.divary.domain.member.dto.response.MyPageImageResponseDTO;
 import com.divary.domain.member.dto.response.MyPageProfileResponseDTO;
@@ -16,7 +17,7 @@ public interface MemberService {
     MyPageImageResponseDTO uploadLicense(MultipartFile image, Long userId);
     DeactivateResponse requestToDeleteMember(Long memberId);
     void cancelDeleteMember(Long memberId);
-    public Member findOrCreateMember(String email);
+    Member findOrCreateMemberBySocialId(String socialId, SocialType socialType, String email);
 
     void updateGroup(Long userId, MyPageGroupRequestDTO requestDTO);
 

--- a/src/main/java/com/divary/global/exception/ErrorCode.java
+++ b/src/main/java/com/divary/global/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     MEMBER_NOT_DEACTIVATED(HttpStatus.BAD_REQUEST, "MEMBER_006", "탈퇴 신청되지 않은 계정입니다."),
     //소셜 로그인 관련
     GOOGLE_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "GOOGLE_001", "구글 유저를 찾을 수 없습니다"),
+    ALREADY_REGISTERED_WITH_DIFFERENT_SOCIAL(HttpStatus.CONFLICT, "AUTH_007", "이미 다른 소셜 계정으로 가입되어 있습니다."),
 
     //알림 관련
     NOTIFICAITION_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_003", "해당 ID를 가진 사용자의 알림이 존재하지 않습니다"),

--- a/src/main/java/com/divary/global/oauth/infra/AppleJwtParser.java
+++ b/src/main/java/com/divary/global/oauth/infra/AppleJwtParser.java
@@ -36,7 +36,7 @@ public class AppleJwtParser {
     /**
      * Apple Identity Token을 검증하고 사용자 정보를 추출합니다.
      * @param identityToken 클라이언트로부터 받은 Identity Token
-     * @return 사용자 정보 (sub: Apple User ID, email: 이메일)
+     * @return 사용자 정보 (sub: Apple User ID, email: 이메일 또는 빈 문자열)
      */
     public Map<String, String> parse(String identityToken) {
         // 1. Apple 공개키 목록을 가져옵니다. (실제 운영에서는 캐싱 필요)
@@ -65,7 +65,13 @@ public class AppleJwtParser {
         // 5. 생성된 PublicKey로 토큰의 서명, 발급자, 만료시간 등을 최종 검증합니다.
         Claims claims = getClaims(identityToken, publicKey);
 
-        return Map.of("sub", claims.getSubject(), "email", claims.get("email", String.class));
+        String sub = claims.getSubject();
+        String email = claims.get("email", String.class);
+
+        return Map.of(
+            "sub", sub,
+            "email", email != null ? email : ""
+        );
     }
 
     /**

--- a/src/main/java/com/divary/global/oauth/service/social/AppleOauth.java
+++ b/src/main/java/com/divary/global/oauth/service/social/AppleOauth.java
@@ -47,9 +47,14 @@ public class AppleOauth implements SocialOauth {
     public LoginResponseDTO verifyAndLogin(String identityToken, String deviceId) {
         // Identity Token을 검증하고 사용자 정보를 추출합니다.
         Map<String, String> userInfo = appleJwtParser.parse(identityToken);
+
+        String sub = userInfo.get("sub");
         String email = userInfo.get("email");
 
-        Member member = memberService.findOrCreateMember(email);
+        log.debug("Apple 로그인 - sub: {}, email: {}", sub, email);
+
+        // socialId(sub)와 socialType으로 회원 조회 또는 생성
+        Member member = memberService.findOrCreateMemberBySocialId(sub, SocialType.APPLE, email);
 
         // 탈퇴 신청된 계정은 로그인 차단
         if (member.getStatus() == Status.DEACTIVATED) {

--- a/src/main/java/com/divary/global/oauth/service/social/GoogleOauth.java
+++ b/src/main/java/com/divary/global/oauth/service/social/GoogleOauth.java
@@ -72,10 +72,13 @@ public class GoogleOauth implements SocialOauth {
     public LoginResponseDTO verifyAndLogin(String googleAccessToken, String deviceId) {
         // accessToken으로 사용자 정보 요청
         Map<String, Object> userInfo = requestUserInfo(googleAccessToken);
+        String sub = (String) userInfo.get("id");  // Google의 고유 사용자 ID
         String email = (String) userInfo.get("email");
 
+        log.debug("Google 로그인 - sub: {}, email: {}", sub, email);
 
-        Member member = memberService.findOrCreateMember(email);
+        // socialId(sub)와 socialType으로 회원 조회 또는 생성
+        Member member = memberService.findOrCreateMemberBySocialId(sub, SocialType.GOOGLE, email);
 
         // 탈퇴 신청된 계정은 로그인 차단
         if (member.getStatus() == Status.DEACTIVATED) {


### PR DESCRIPTION
- Member 엔티티에 socialId, socialType 필드 추가 (복합 유니크 제약)
- Apple/Google 로그인 시 sub/id를 socialId로 사용하여 회원 조회
- 기존 회원 자동 마이그레이션 로직 추가 (socialId null인 경우 업데이트)
- 다른 소셜 타입 중복 가입 방지 및 에러 처리

## 🔗 관련 이슈

#200 

---

## 📌 PR 요약

   Apple과 Google 소셜 로그인을 email 기반에서 socialId(sub/id) 기반으로 변경하고, 기존 회원 자동 마이그레이션 로직을 추가

   ---

   ## 📑 작업 내용

   1. Member 엔티티에 socialId, socialType 필드 추가 (복합 유니크 제약)
   2. Apple/Google 로그인 시 sub/id를 socialId로 사용하여 회원 조회
   3. 기존 회원(socialId null) 자동 마이그레이션 로직 추가
   4. 다른 소셜 타입 중복 가입 방지 및 에러 처리 (AUTH_007 추가)
   5. MemberRepository에 findBySocialIdAndSocialType 메서드 추가
   6. Member 엔티티에 updateSocialInfo 비즈니스 메서드 추가

   ---

   ## 스크린샷 (선택)


   ---


## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
