### PR TITLE
 fix/#209: Facade 패턴 적용으로 순환참조 해결

### DIFF
--- a/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
+++ b/src/main/java/com/divary/domain/logbase/logbook/service/LogBookService.java
@@ -1,7 +1,7 @@
 package com.divary.domain.logbase.logbook.service;
 
 import com.divary.domain.member.entity.Member;
-import com.divary.domain.member.service.MemberServiceImpl;
+import com.divary.domain.member.service.MemberService;
 import com.divary.domain.logbase.LogBaseInfo;
 import com.divary.domain.logbase.LogBaseInfoRepository;
 import com.divary.domain.logbase.logbook.dto.request.*;
@@ -33,7 +33,7 @@ public class LogBookService {
     private final LogBaseInfoRepository logBaseInfoRepository;
     private final LogBookRepository logBookRepository;
     private final CompanionRepository companionRepository;
-    private final MemberServiceImpl memberService;
+    private final MemberService memberService;
 
     @Transactional
     public LogBaseCreateResultDTO createLogBase

--- a/src/main/java/com/divary/domain/member/controller/MemberController.java
+++ b/src/main/java/com/divary/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.divary.domain.member.dto.requestDTO.MyPageGroupRequestDTO;
 import com.divary.domain.member.dto.requestDTO.MyPageLevelRequestDTO;
 import com.divary.domain.member.dto.response.MyPageImageResponseDTO;
 import com.divary.domain.member.dto.response.MyPageProfileResponseDTO;
+import com.divary.domain.member.facade.MyPageFacade;
 import com.divary.global.config.SwaggerConfig;
 import com.divary.global.config.security.CustomUserPrincipal;
 import com.divary.global.exception.ErrorCode;
@@ -22,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+    private final MyPageFacade myPageFacade;
 
     @PatchMapping("/level")
     @SwaggerConfig.ApiSuccessResponse(dataType = Void.class)
@@ -53,7 +55,7 @@ public class MemberController {
     @SwaggerConfig.ApiSuccessResponse(dataType = Void.class)
     @SwaggerConfig.ApiErrorExamples(value = {ErrorCode.AUTHENTICATION_REQUIRED})
     public ApiResponse getProfile(@AuthenticationPrincipal CustomUserPrincipal userPrincipal){
-        MyPageProfileResponseDTO responseDTO = memberService.getMemberProfile(userPrincipal.getId());
+        MyPageProfileResponseDTO responseDTO = myPageFacade.getMemberProfile(userPrincipal.getId());
         return ApiResponse.success(responseDTO);
     }
 

--- a/src/main/java/com/divary/domain/member/facade/MyPageFacade.java
+++ b/src/main/java/com/divary/domain/member/facade/MyPageFacade.java
@@ -1,0 +1,55 @@
+package com.divary.domain.member.facade;
+
+import com.divary.domain.logbase.logbook.service.LogBookService;
+import com.divary.domain.member.dto.response.MyPageProfileResponseDTO;
+import com.divary.domain.member.entity.Member;
+import com.divary.domain.member.service.MemberService;
+import com.divary.global.exception.BusinessException;
+import com.divary.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * MyPage Facade
+ * 여러 도메인 서비스를 조합하여 마이페이지 관련 비즈니스 로직을 처리합니다.
+ *
+ * 목적:
+ * 1. MemberService와 LogBookService 간의 순환참조 제거
+ * 2. 여러 도메인의 데이터를 조합하는 책임 분리
+ * 3. 향후 소셜 기능(친구 등) 추가 시 확장성 확보
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageFacade {
+
+    private final MemberService memberService;
+    private final LogBookService logBookService;
+
+    /**
+     * 마이페이지 프로필 정보 조회
+     * Member 정보와 LogBook 누적 횟수를 조합하여 반환
+     *
+     * @param userId 사용자 ID
+     * @return 마이페이지 프로필 정보
+     */
+    public MyPageProfileResponseDTO getMemberProfile(Long userId) {
+        // 1. Member 도메인 데이터 조회
+        Member member = memberService.findById(userId);
+
+        // 2. LogBook 도메인 데이터 조회
+        Integer accumulation = logBookService.getAccumulationById(userId);
+
+        // 3. 비즈니스 로직: 이메일에서 ID 추출
+        String memberIdByEmail = member.getEmail().split("@")[0];
+
+        // 4. DTO 조합 및 반환
+        return MyPageProfileResponseDTO.builder()
+                .memberGroup(member.getMemberGroup())
+                .level(member.getLevel())
+                .id(memberIdByEmail)
+                .accumulations(accumulation)
+                .build();
+    }
+}

--- a/src/main/java/com/divary/domain/member/service/MemberService.java
+++ b/src/main/java/com/divary/domain/member/service/MemberService.java
@@ -3,7 +3,6 @@ package com.divary.domain.member.service;
 import com.divary.common.enums.SocialType;
 import com.divary.domain.member.dto.requestDTO.MyPageGroupRequestDTO;
 import com.divary.domain.member.dto.response.MyPageImageResponseDTO;
-import com.divary.domain.member.dto.response.MyPageProfileResponseDTO;
 import com.divary.domain.member.entity.Member;
 import com.divary.domain.member.dto.requestDTO.MyPageLevelRequestDTO;
 import com.divary.global.oauth.dto.response.DeactivateResponse;
@@ -20,8 +19,6 @@ public interface MemberService {
     Member findOrCreateMemberBySocialId(String socialId, SocialType socialType, String email);
 
     void updateGroup(Long userId, MyPageGroupRequestDTO requestDTO);
-
-    MyPageProfileResponseDTO getMemberProfile(Long userId);
 
     MyPageImageResponseDTO getLicenseImage(Long userId);
 }

--- a/src/main/java/com/divary/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/divary/domain/member/service/MemberServiceImpl.java
@@ -5,8 +5,6 @@ import com.divary.common.util.EnumValidator;
 import com.divary.domain.image.dto.request.ImageUploadRequest;
 import com.divary.domain.image.dto.response.ImageResponse;
 import com.divary.domain.image.service.ImageService;
-import com.divary.domain.logbase.logbook.enums.SaveStatus;
-import com.divary.domain.logbase.logbook.service.LogBookService;
 import com.divary.domain.member.dto.requestDTO.MyPageGroupRequestDTO;
 import com.divary.domain.member.dto.requestDTO.MyPageLevelRequestDTO;
 import com.divary.domain.member.dto.response.MyPageImageResponseDTO;
@@ -41,7 +39,6 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
     private final ImageService imageService;
     private final TokenBlackListService tokenBlackListService;
-    private final LogBookService logBookService;
 
     @Value("${jobs.user-deletion.grace-period-days}")
     private int gracePeriodDays;
@@ -199,24 +196,6 @@ public class MemberServiceImpl implements MemberService {
         member.updateGroup(group);
     }
 
-    @Override
-    public MyPageProfileResponseDTO getMemberProfile(Long userId){
-        Member member = memberRepository.findById(userId).orElseThrow(()->new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-
-        Integer accumulation
-                = logBookService.getAccumulationById(userId);
-        //현재기준으로 총 로그북 누적횟수 계산
-
-        String memberIdByEmail = member.getEmail().split("@")[0];
-        // 프로필에 나오는 아이디: 이메일에서 @ 앞부분만 추출
-
-        return MyPageProfileResponseDTO.builder()
-                .memberGroup(member.getMemberGroup())
-                .level(member.getLevel())
-                .id(memberIdByEmail)
-                .accumulations(accumulation)
-                .build();
-    }
 
     @Override
     public MyPageImageResponseDTO getLicenseImage(Long userId){


### PR DESCRIPTION
  MemberServiceImpl과 LogBookService 간 순환참조를 해결하기 위해
  MyPageFacade를 도입하여 여러 도메인 서비스 조합 책임을 분리

  변경사항:
  - MyPageFacade 생성: Member와 LogBook 도메인 조합
  - MemberServiceImpl에서 LogBookService 의존성 제거
  - LogBookService가 MemberService 인터페이스 의존으로 변경
  - MemberController에서 MyPageFacade 사용

  아키텍처 개선:
  - 도메인 서비스는 각자 도메인만 담당
  - Facade가 여러 도메인 조합 (Use Case 레이어)
  - 향후 소셜/친구 기능 확장성 확보

## 🔗 관련 이슈

연관된 이슈 번호를 적어주세요. (예: #123)
#209 
---

## 📌 PR 요약
 Facade 패턴 적용으로 순환참조 해결
---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
  - MyPageFacade 생성: Member와 LogBook 도메인 조합
  - MemberServiceImpl에서 LogBookService 의존성 제거
  - LogBookService가 MemberService 인터페이스 의존으로 변경
  - MemberController에서 MyPageFacade 사용

---

## 스크린샷 (선택)


---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
